### PR TITLE
chore: bump version to 1.0.2 and update dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,20 @@
 {
   "name": "kickstart-nuxt-ssr",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kickstart-nuxt-ssr",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@contentstack/delivery-sdk": "^4.7.0",
         "@contentstack/live-preview-utils": "^3.2.2",
         "@nuxtjs/tailwindcss": "^6.14.0",
-        "@timbenniks/contentstack-endpoints": "^1.0.9",
-        "nuxt": "^3.17.3",
+        "@timbenniks/contentstack-endpoints": "^1.0.10",
+        "nuxt": "^3.17.4",
         "vue": "latest",
         "vue-router": "latest"
       }
@@ -1179,14 +1179,14 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.9.tgz",
-      "integrity": "sha512-OKRBiajrrxB9ATokgEQoG87Z25c67pCpYcCwmXYX8PBftC9pBfN18gnm/fh1wurSLEKIAt+QRFLFCQISrb66Jg==",
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.10.tgz",
+      "integrity": "sha512-bCsCyeZEwVErsGmyPNSzwfwFn4OdxBj0mmv6hOFucB/k81Ojdu68RbZdxYsRQUPc9l6SU5F/cG+bXgWs3oUgsQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "^1.4.0",
-        "@emnapi/runtime": "^1.4.0",
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
         "@tybys/wasm-util": "^0.9.0"
       }
     },
@@ -2127,12 +2127,12 @@
       }
     },
     "node_modules/@nuxt/kit": {
-      "version": "3.17.3",
-      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.17.3.tgz",
-      "integrity": "sha512-aw6u6mT3TnM/MmcCRDMv3i9Sbm5/ZMSJgDl+N+WsrWNDIQ2sWmsqdDkjb/HyXF20SNwc2891hRBkaQr3hG2mhA==",
+      "version": "3.17.4",
+      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.17.4.tgz",
+      "integrity": "sha512-l+hY8sy2XFfg3PigZj+PTu6+KIJzmbACTRimn1ew/gtCz+F38f6KTF4sMRTN5CUxiB8TRENgEonASmkAWfpO9Q==",
       "license": "MIT",
       "dependencies": {
-        "c12": "^3.0.3",
+        "c12": "^3.0.4",
         "consola": "^3.4.2",
         "defu": "^6.1.4",
         "destr": "^2.0.5",
@@ -2147,7 +2147,7 @@
         "pathe": "^2.0.3",
         "pkg-types": "^2.1.0",
         "scule": "^1.3.0",
-        "semver": "^7.7.1",
+        "semver": "^7.7.2",
         "std-env": "^3.9.0",
         "tinyglobby": "^0.2.13",
         "ufo": "^1.6.1",
@@ -2160,12 +2160,12 @@
       }
     },
     "node_modules/@nuxt/schema": {
-      "version": "3.17.3",
-      "resolved": "https://registry.npmjs.org/@nuxt/schema/-/schema-3.17.3.tgz",
-      "integrity": "sha512-z4hbeTtg8B2/2I8zqnCAQQ9JmIQA/BfFy/8cRkGKRIMNjOaTOdmAqMnNriSpyp9xfzWGpnvxPFgab/5uSjsAgA==",
+      "version": "3.17.4",
+      "resolved": "https://registry.npmjs.org/@nuxt/schema/-/schema-3.17.4.tgz",
+      "integrity": "sha512-bsfJdWjKNYLkVQt7Ykr9YsAql1u8Tuo6iecSUOltTIhsvAIYsknRFPHoNKNmaiv/L6FgCQgUgQppPTPUAXiJQQ==",
       "license": "MIT",
       "dependencies": {
-        "@vue/shared": "^3.5.13",
+        "@vue/shared": "^3.5.14",
         "consola": "^3.4.2",
         "defu": "^6.1.4",
         "pathe": "^2.0.3",
@@ -2202,15 +2202,15 @@
       }
     },
     "node_modules/@nuxt/vite-builder": {
-      "version": "3.17.3",
-      "resolved": "https://registry.npmjs.org/@nuxt/vite-builder/-/vite-builder-3.17.3.tgz",
-      "integrity": "sha512-WK1ESdzbJGRwLGz6s+oyVwM3Ore4V/eYMyquUYsdckFC0rTOnRlV88jdGf0D8Yav0DkrNrG5nZEkL8k+zuXlwQ==",
+      "version": "3.17.4",
+      "resolved": "https://registry.npmjs.org/@nuxt/vite-builder/-/vite-builder-3.17.4.tgz",
+      "integrity": "sha512-MRcGe02nEDpu+MnRJcmgVfHdzgt9tWvxVdJbhfd6oyX19plw/CANjgHedlpUNUxqeWXC6CQfGvoVJXn3bQlEqA==",
       "license": "MIT",
       "dependencies": {
-        "@nuxt/kit": "3.17.3",
+        "@nuxt/kit": "3.17.4",
         "@rollup/plugin-replace": "^6.0.2",
         "@vitejs/plugin-vue": "^5.2.4",
-        "@vitejs/plugin-vue-jsx": "^4.1.2",
+        "@vitejs/plugin-vue-jsx": "^4.2.0",
         "autoprefixer": "^10.4.21",
         "consola": "^3.4.2",
         "cssnano": "^7.0.7",
@@ -2234,10 +2234,10 @@
         "rollup-plugin-visualizer": "^5.14.0",
         "std-env": "^3.9.0",
         "ufo": "^1.6.1",
-        "unenv": "^2.0.0-rc.15",
-        "unplugin": "^2.3.3",
+        "unenv": "^2.0.0-rc.17",
+        "unplugin": "^2.3.4",
         "vite": "^6.3.5",
-        "vite-node": "^3.1.3",
+        "vite-node": "^3.1.4",
         "vite-plugin-checker": "^0.9.3",
         "vue-bundle-renderer": "^2.1.1"
       },
@@ -2273,9 +2273,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-darwin-arm64": {
-      "version": "0.69.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.69.0.tgz",
-      "integrity": "sha512-4kmSjKARywwCxQ9udJy8T6XJwe7LzfAf0Yy38O1DsRyK05twKgBGWBca2vfaNi4V8jpNaA6SPJi+KJE5IKLLpw==",
+      "version": "0.71.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.71.0.tgz",
+      "integrity": "sha512-7R7TuHWL2hZ8BbRdxXlVJTE0os7TM6LL2EX2OkIz41B3421JeIU+2YH+IV55spIUy5E5ynesLk0IdpSSPVZ25Q==",
       "cpu": [
         "arm64"
       ],
@@ -2289,9 +2289,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-darwin-x64": {
-      "version": "0.69.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.69.0.tgz",
-      "integrity": "sha512-RQgFiCbv5wTXxFEKgVcUcU2l62zTZZRVXZPUiLtOf4EY0/P/H6pSK6/ATiTVAZVqy72xDE0lWONZbFcUMPwnHw==",
+      "version": "0.71.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.71.0.tgz",
+      "integrity": "sha512-Q7QshRy7cDvpvWAH+qy2U8O9PKo5yEKFqPruD2OSOM8igy/GLIC21dAd6iCcqXRZxaqzN9c4DaXFtEZfq4NWsw==",
       "cpu": [
         "x64"
       ],
@@ -2305,9 +2305,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-freebsd-x64": {
-      "version": "0.69.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.69.0.tgz",
-      "integrity": "sha512-LGmg4kVxq910jrvZJLT2vJYScz6+ANMoYSR2EWEbhA4HALo3I3/055dgZ8GV001ALaPPz/L6AbvxaYPVAGPRfQ==",
+      "version": "0.71.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.71.0.tgz",
+      "integrity": "sha512-z8NNBBseLriz2p+eJ8HWC+A8P+MsO8HCtXie9zaVlVcXSiUuBroRWeXopvHN4r+tLzmN2iLXlXprJdNhXNgobQ==",
       "cpu": [
         "x64"
       ],
@@ -2321,9 +2321,25 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
-      "version": "0.69.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.69.0.tgz",
-      "integrity": "sha512-Q5jWCHy82c9vYBZVQVSB8ZARLAxU5bMgVDZBHRMDB/gQJhphJaZ23wqPQ2b8b2XSoJhssQhYMV0bF600TzAfpg==",
+      "version": "0.71.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.71.0.tgz",
+      "integrity": "sha512-QZQcWMduFRWddqvjgLvsWoeellFjvWqvdI0O1m5hoMEykv2/Ag8d7IZbBwRwFqKBuK4UzpBNt4jZaYzRsv1irg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
+      "version": "0.71.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.71.0.tgz",
+      "integrity": "sha512-lTDc2WCzllVFXugUHQGR904CksA5BiHc35mcH6nJm6h0FCdoyn9zefW8Pelku5ET39JgO1OENEm/AyNvf/FzIw==",
       "cpu": [
         "arm"
       ],
@@ -2337,9 +2353,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-arm64-gnu": {
-      "version": "0.69.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.69.0.tgz",
-      "integrity": "sha512-PsuAduOi5Cz+YdpL3LyVBvN+h5fjHAgMCibaAfGa7ru2zr6tb6r5IAfBBj3KHkFYoyl7ztodQSnWsA2Fka3QPw==",
+      "version": "0.71.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.71.0.tgz",
+      "integrity": "sha512-mAA6JGS+MB+gbN5y/KuQ095EHYGF7a/FaznM7klk5CaCap/UdiRWCVinVV6xXmejOPZMnrkr6R5Kqi6dHRsm2g==",
       "cpu": [
         "arm64"
       ],
@@ -2353,9 +2369,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-arm64-musl": {
-      "version": "0.69.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.69.0.tgz",
-      "integrity": "sha512-vOxh5Hk22YlfxuQvxRmkzT+VrAd901sDz1gkPUf2u+HCNyDMXq+O/jXn68wFQQgbkDKpAfP0z2dZfOJFkkL2Ag==",
+      "version": "0.71.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.71.0.tgz",
+      "integrity": "sha512-PaPmIEM0yldXSrO1Icrx6/DwnMXpEOv0bDVa0LFtwy2I+aiTiX7OVRB3pJCg8FEV9P+L48s9XW0Oaz+Dz3o3sQ==",
       "cpu": [
         "arm64"
       ],
@@ -2369,9 +2385,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
-      "version": "0.69.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.69.0.tgz",
-      "integrity": "sha512-5xQpOPaGgxqyUa8T7yOeXPI/tO4o7pmRV++od1XFH+HR8GvidS0J0rC7F69aqz39+i6x6rc5ZxwWADLPtR45rQ==",
+      "version": "0.71.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.71.0.tgz",
+      "integrity": "sha512-+AEGO6gOSSEqWTrCCYayNMMPe/qi83o1czQ5bytEFQtyvWdgLwliqqShpJtgSLj1SNWi94HiA/VOfqqZnGE1AQ==",
       "cpu": [
         "riscv64"
       ],
@@ -2385,9 +2401,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-s390x-gnu": {
-      "version": "0.69.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.69.0.tgz",
-      "integrity": "sha512-btrmwQ/mds4We2nS/GSg03wj9iClgQkbgf6c8WWXhr4l5GmpxLH6t1LnS4s+tHpTWSY7jpegRfOwQalS5D3Y6g==",
+      "version": "0.71.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.71.0.tgz",
+      "integrity": "sha512-zqFnheBACFzrRl401ylXufNl1YsOdVa8jwS2iSCwJFx4/JdQhE6Y4YWoEjQ/pzeRZXwI5FX4C607rQe2YdhggQ==",
       "cpu": [
         "s390x"
       ],
@@ -2401,9 +2417,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-x64-gnu": {
-      "version": "0.69.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.69.0.tgz",
-      "integrity": "sha512-IfFNgUcdzISFausz7k6gdo1zUydJLExVrwpoCRyDYnsPovgOJHhxVZZ6sbuYbufcRh6PV/aA7G8RIvNmOVjIwQ==",
+      "version": "0.71.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.71.0.tgz",
+      "integrity": "sha512-steSQTwv3W+/hpES4/9E3vNohou1FXJLNWLDbYHDaBI9gZdYJp6zwALC8EShCz0NoQvCu4THD3IBsTBHvFBNyw==",
       "cpu": [
         "x64"
       ],
@@ -2417,9 +2433,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-x64-musl": {
-      "version": "0.69.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.69.0.tgz",
-      "integrity": "sha512-dEOj+Lnwy2GNiAzon05Mo1DP1ptpQNbm12Bz+ZVm/vDNHY0Zbgjf7i3MpnnEywFL8NZJ1c6vSDmtDqTdnm2EBw==",
+      "version": "0.71.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.71.0.tgz",
+      "integrity": "sha512-mV8j/haQBZRU2QnwZe0UIpnhpPBL9dFk1tgNVSH9tV7cV4xUZPn7pFDqMriAmpD7GLfmxbZMInDkujokd63M7Q==",
       "cpu": [
         "x64"
       ],
@@ -2433,25 +2449,25 @@
       }
     },
     "node_modules/@oxc-parser/binding-wasm32-wasi": {
-      "version": "0.69.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.69.0.tgz",
-      "integrity": "sha512-M7HM82ZIeIIYN3DrbN6gsM6Z2RTv/nEe2CsQdeblxmM9CfXCyi55YOxtxo1+8iYoy8NV5EGUeCOwY7YR1JAt6A==",
+      "version": "0.71.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.71.0.tgz",
+      "integrity": "sha512-P8ScINpuihkkBX8BrN/4x4ka2+izncHh7/hHxxuPZDZTVMyNNnL1uSoI80tN9yN7NUtUKoi9aQUaF4h22RQcIA==",
       "cpu": [
         "wasm32"
       ],
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@napi-rs/wasm-runtime": "^0.2.9"
+        "@napi-rs/wasm-runtime": "^0.2.10"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@oxc-parser/binding-win32-arm64-msvc": {
-      "version": "0.69.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.69.0.tgz",
-      "integrity": "sha512-M5W0p0WGjshiCGUNugoHs+8XWgd5J2CrSHY8rYrEmp632LhHRQUGC9AwI45B6IYvnRXiK6E4zcGj/Bey2Dqhyg==",
+      "version": "0.71.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.71.0.tgz",
+      "integrity": "sha512-4jrJSdBXHmLYaghi1jvbuJmWu117wxqCpzHHgpEV9xFiRSngtClqZkNqyvcD4907e/VriEwluZ3PO3Mlp0y9cw==",
       "cpu": [
         "arm64"
       ],
@@ -2465,9 +2481,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-win32-x64-msvc": {
-      "version": "0.69.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.69.0.tgz",
-      "integrity": "sha512-flBEF+3dJOi3Nm3b7kNxVGrtuSBGN7RNs/qWPHvq/FUP6xFEsT3hvcdNBUnzB15hPsyExptlKyihgZjYhfpgpA==",
+      "version": "0.71.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.71.0.tgz",
+      "integrity": "sha512-zF7xF19DOoANym/xwVClYH1tiW3S70W8ZDrMHdrEB7gZiTYLCIKIRMrpLVKaRia6LwEo7X0eduwdBa5QFawxOw==",
       "cpu": [
         "x64"
       ],
@@ -2481,9 +2497,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.69.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.69.0.tgz",
-      "integrity": "sha512-bu3gzdAlLgncoaqyqWVpMAKx4axo+j3ewvvdAt5iCLtvHB/n3Qeif67NU+2TM/ami1nV5/KVO9lxCH8paPATBA==",
+      "version": "0.71.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.71.0.tgz",
+      "integrity": "sha512-5CwQ4MI+P4MQbjLWXgNurA+igGwu/opNetIE13LBs9+V93R64MLvDKOOLZIXSzEfovU3Zef3q3GjPnMTgJTn2w==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
@@ -2913,6 +2929,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
       }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.9.tgz",
+      "integrity": "sha512-e9MeMtVWo186sgvFFJOPGy7/d2j2mZhLJIdVW0C/xDluuOvymEATqz6zKsP0ZmXGzQtqlyjz5sC1sYQUoJG98w==",
+      "license": "MIT"
     },
     "node_modules/@rollup/plugin-alias": {
       "version": "5.1.1",
@@ -3397,9 +3419,9 @@
       "license": "CC0-1.0"
     },
     "node_modules/@timbenniks/contentstack-endpoints": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@timbenniks/contentstack-endpoints/-/contentstack-endpoints-1.0.9.tgz",
-      "integrity": "sha512-yVU2JcbBMZIMMazWUoqouIurIhrrBLCdWZRJWEuEaXAMbEsr33ZsBEIl8YsYofDa4JD47NjbE6HU32mimTJf5A==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@timbenniks/contentstack-endpoints/-/contentstack-endpoints-1.0.10.tgz",
+      "integrity": "sha512-BvMDN9FemZVGud7zZOV/qZmrYxEKvs9xjm/TUvBv0RdYjqRKCFCn3+JlS99etSvhUt0wweVTX98ROZorII56oA==",
       "license": "MIT"
     },
     "node_modules/@trysound/sax": {
@@ -3574,13 +3596,13 @@
       }
     },
     "node_modules/@unhead/vue": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@unhead/vue/-/vue-2.0.8.tgz",
-      "integrity": "sha512-e30+CfCl1avR+hzFtpvnBSesZ5TN2KbShStdT2Z+zs5WIBUvobQwVxSR0arX43To6KfwtCXAfi0iOOIH0kufHQ==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@unhead/vue/-/vue-2.0.10.tgz",
+      "integrity": "sha512-lV7E1sXX6/te8+IiUwlMysBAyJT/WM5Je47cRnpU5hsvDRziSIGfim9qMWbsTouH+paavRJz1i8gk5hRzjvkcw==",
       "license": "MIT",
       "dependencies": {
         "hookable": "^5.5.3",
-        "unhead": "2.0.8"
+        "unhead": "2.0.10"
       },
       "funding": {
         "url": "https://github.com/sponsors/harlan-zw"
@@ -3635,14 +3657,15 @@
       }
     },
     "node_modules/@vitejs/plugin-vue-jsx": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue-jsx/-/plugin-vue-jsx-4.1.2.tgz",
-      "integrity": "sha512-4Rk0GdE0QCdsIkuMmWeg11gmM4x8UmTnZR/LWPm7QJ7+BsK4tq08udrN0isrrWqz5heFy9HLV/7bOLgFS8hUjA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue-jsx/-/plugin-vue-jsx-4.2.0.tgz",
+      "integrity": "sha512-DSTrmrdLp+0LDNF77fqrKfx7X0ErRbOcUAgJL/HbSesqQwoUvUQ4uYQqaex+rovqgGcoPqVk+AwUh3v9CuiYIw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/core": "^7.26.7",
-        "@babel/plugin-transform-typescript": "^7.26.7",
-        "@vue/babel-plugin-jsx": "^1.2.5"
+        "@babel/core": "^7.27.1",
+        "@babel/plugin-transform-typescript": "^7.27.1",
+        "@rolldown/pluginutils": "^1.0.0-beta.9",
+        "@vue/babel-plugin-jsx": "^1.4.0"
       },
       "engines": {
         "node": "^18.0.0 || >=20.0.0"
@@ -3728,16 +3751,16 @@
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.5.13",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.13.tgz",
-      "integrity": "sha512-oOdAkwqUfW1WqpwSYJce06wvt6HljgY3fGeM9NcVA1HaYOij3mZG9Rkysn0OHuyUAGMbEbARIpsG+LPVlBJ5/Q==",
+      "version": "3.5.15",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.15.tgz",
+      "integrity": "sha512-nGRc6YJg/kxNqbv/7Tg4juirPnjHvuVdhcmDvQWVZXlLHjouq7VsKmV1hIxM/8yKM0VUfwT/Uzc0lO510ltZqw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.25.3",
-        "@vue/shared": "3.5.13",
+        "@babel/parser": "^7.27.2",
+        "@vue/shared": "3.5.15",
         "entities": "^4.5.0",
         "estree-walker": "^2.0.2",
-        "source-map-js": "^1.2.0"
+        "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/compiler-core/node_modules/estree-walker": {
@@ -3747,30 +3770,30 @@
       "license": "MIT"
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.5.13",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.13.tgz",
-      "integrity": "sha512-ZOJ46sMOKUjO3e94wPdCzQ6P1Lx/vhp2RSvfaab88Ajexs0AHeV0uasYhi99WPaogmBlRHNRuly8xV75cNTMDA==",
+      "version": "3.5.15",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.15.tgz",
+      "integrity": "sha512-ZelQd9n+O/UCBdL00rlwCrsArSak+YLZpBVuNDio1hN3+wrCshYZEDUO3khSLAzPbF1oQS2duEoMDUHScUlYjA==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-core": "3.5.13",
-        "@vue/shared": "3.5.13"
+        "@vue/compiler-core": "3.5.15",
+        "@vue/shared": "3.5.15"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.5.13",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.13.tgz",
-      "integrity": "sha512-6VdaljMpD82w6c2749Zhf5T9u5uLBWKnVue6XWxprDobftnletJ8+oel7sexFfM3qIxNmVE7LSFGTpv6obNyaQ==",
+      "version": "3.5.15",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.15.tgz",
+      "integrity": "sha512-3zndKbxMsOU6afQWer75Zot/aydjtxNj0T2KLg033rAFaQUn2PGuE32ZRe4iMhflbTcAxL0yEYsRWFxtPro8RQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.25.3",
-        "@vue/compiler-core": "3.5.13",
-        "@vue/compiler-dom": "3.5.13",
-        "@vue/compiler-ssr": "3.5.13",
-        "@vue/shared": "3.5.13",
+        "@babel/parser": "^7.27.2",
+        "@vue/compiler-core": "3.5.15",
+        "@vue/compiler-dom": "3.5.15",
+        "@vue/compiler-ssr": "3.5.15",
+        "@vue/shared": "3.5.15",
         "estree-walker": "^2.0.2",
-        "magic-string": "^0.30.11",
-        "postcss": "^8.4.48",
-        "source-map-js": "^1.2.0"
+        "magic-string": "^0.30.17",
+        "postcss": "^8.5.3",
+        "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/compiler-sfc/node_modules/estree-walker": {
@@ -3780,13 +3803,13 @@
       "license": "MIT"
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.5.13",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.13.tgz",
-      "integrity": "sha512-wMH6vrYHxQl/IybKJagqbquvxpWCuVYpoUJfCqFZwa/JY1GdATAQ+TgVtgrwwMZ0D07QhA99rs/EAAWfvG6KpA==",
+      "version": "3.5.15",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.15.tgz",
+      "integrity": "sha512-gShn8zRREZbrXqTtmLSCffgZXDWv8nHc/GhsW+mbwBfNZL5pI96e7IWcIq8XGQe1TLtVbu7EV9gFIVSmfyarPg==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.5.13",
-        "@vue/shared": "3.5.13"
+        "@vue/compiler-dom": "3.5.15",
+        "@vue/shared": "3.5.15"
       }
     },
     "node_modules/@vue/devtools-api": {
@@ -3837,53 +3860,53 @@
       }
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.5.13",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.13.tgz",
-      "integrity": "sha512-NaCwtw8o48B9I6L1zl2p41OHo/2Z4wqYGGIK1Khu5T7yxrn+ATOixn/Udn2m+6kZKB/J7cuT9DbWWhRxqixACg==",
+      "version": "3.5.15",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.15.tgz",
+      "integrity": "sha512-GaA5VUm30YWobCwpvcs9nvFKf27EdSLKDo2jA0IXzGS344oNpFNbEQ9z+Pp5ESDaxyS8FcH0vFN/XSe95BZtHQ==",
       "license": "MIT",
       "dependencies": {
-        "@vue/shared": "3.5.13"
+        "@vue/shared": "3.5.15"
       }
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.5.13",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.13.tgz",
-      "integrity": "sha512-Fj4YRQ3Az0WTZw1sFe+QDb0aXCerigEpw418pw1HBUKFtnQHWzwojaukAs2X/c9DQz4MQ4bsXTGlcpGxU/RCIw==",
+      "version": "3.5.15",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.15.tgz",
+      "integrity": "sha512-CZAlIOQ93nj0OPpWWOx4+QDLCMzBNY85IQR4Voe6vIID149yF8g9WQaWnw042f/6JfvLttK7dnyWlC1EVCRK8Q==",
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.5.13",
-        "@vue/shared": "3.5.13"
+        "@vue/reactivity": "3.5.15",
+        "@vue/shared": "3.5.15"
       }
     },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.5.13",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.13.tgz",
-      "integrity": "sha512-dLaj94s93NYLqjLiyFzVs9X6dWhTdAlEAciC3Moq7gzAc13VJUdCnjjRurNM6uTLFATRHexHCTu/Xp3eW6yoog==",
+      "version": "3.5.15",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.15.tgz",
+      "integrity": "sha512-wFplHKzKO/v998up2iCW3RN9TNUeDMhdBcNYZgs5LOokHntrB48dyuZHspcahKZczKKh3v6i164gapMPxBTKNw==",
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.5.13",
-        "@vue/runtime-core": "3.5.13",
-        "@vue/shared": "3.5.13",
+        "@vue/reactivity": "3.5.15",
+        "@vue/runtime-core": "3.5.15",
+        "@vue/shared": "3.5.15",
         "csstype": "^3.1.3"
       }
     },
     "node_modules/@vue/server-renderer": {
-      "version": "3.5.13",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.13.tgz",
-      "integrity": "sha512-wAi4IRJV/2SAW3htkTlB+dHeRmpTiVIK1OGLWV1yeStVSebSQQOwGwIq0D3ZIoBj2C2qpgz5+vX9iEBkTdk5YA==",
+      "version": "3.5.15",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.15.tgz",
+      "integrity": "sha512-Gehc693kVTYkLt6QSYEjGvqvdK2zZ/gf/D5zkgmvBdeB30dNnVZS8yY7+IlBmHRd1rR/zwaqeu06Ij04ZxBscg==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-ssr": "3.5.13",
-        "@vue/shared": "3.5.13"
+        "@vue/compiler-ssr": "3.5.15",
+        "@vue/shared": "3.5.15"
       },
       "peerDependencies": {
-        "vue": "3.5.13"
+        "vue": "3.5.15"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.5.13",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.13.tgz",
-      "integrity": "sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ==",
+      "version": "3.5.15",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.15.tgz",
+      "integrity": "sha512-bKvgFJJL1ZX9KxMCTQY6xD9Dhe3nusd1OhyOb1cJYGqvAr0Vg8FIjHPMOEVbJ9GDT9HG+Bjdn4oS8ohKP8EvoA==",
       "license": "MIT"
     },
     "node_modules/@whatwg-node/disposablestack": {
@@ -4558,16 +4581,16 @@
       }
     },
     "node_modules/c12": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/c12/-/c12-3.0.3.tgz",
-      "integrity": "sha512-uC3MacKBb0Z15o5QWCHvHWj5Zv34pGQj9P+iXKSpTuSGFS0KKhUWf4t9AJ+gWjYOdmWCPEGpEzm8sS0iqbpo1w==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/c12/-/c12-3.0.4.tgz",
+      "integrity": "sha512-t5FaZTYbbCtvxuZq9xxIruYydrAGsJ+8UdP0pZzMiK2xl/gNiSOy0OxhLzHUEEb0m1QXYqfzfvyIFEmz/g9lqg==",
       "license": "MIT",
       "dependencies": {
         "chokidar": "^4.0.3",
         "confbox": "^0.2.2",
         "defu": "^6.1.4",
-        "dotenv": "^16.4.7",
-        "exsolve": "^1.0.4",
+        "dotenv": "^16.5.0",
+        "exsolve": "^1.0.5",
         "giget": "^2.0.0",
         "jiti": "^2.4.2",
         "ohash": "^2.0.11",
@@ -5838,9 +5861,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.4.7",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
-      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
+      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -8885,21 +8908,21 @@
       }
     },
     "node_modules/nuxt": {
-      "version": "3.17.3",
-      "resolved": "https://registry.npmjs.org/nuxt/-/nuxt-3.17.3.tgz",
-      "integrity": "sha512-iaRGGcnOiahdz+rhEiDY+Ep/vgsvcCCSs2tIVwKmteHEZk6O2zcpk/U1rHxPWortTyMlluHHaohC2WngYceh+g==",
+      "version": "3.17.4",
+      "resolved": "https://registry.npmjs.org/nuxt/-/nuxt-3.17.4.tgz",
+      "integrity": "sha512-49tkp7/+QVhuEOFoTDVvNV6Pc5+aI7wWjZHXzLUrt3tlWLPFh0yYbNXOc3kaxir1FuhRQHHyHZ7azCPmGukfFg==",
       "license": "MIT",
       "dependencies": {
         "@nuxt/cli": "^3.25.1",
         "@nuxt/devalue": "^2.0.2",
-        "@nuxt/devtools": "^2.4.0",
-        "@nuxt/kit": "3.17.3",
-        "@nuxt/schema": "3.17.3",
+        "@nuxt/devtools": "^2.4.1",
+        "@nuxt/kit": "3.17.4",
+        "@nuxt/schema": "3.17.4",
         "@nuxt/telemetry": "^2.6.6",
-        "@nuxt/vite-builder": "3.17.3",
-        "@unhead/vue": "^2.0.8",
-        "@vue/shared": "^3.5.13",
-        "c12": "^3.0.3",
+        "@nuxt/vite-builder": "3.17.4",
+        "@unhead/vue": "^2.0.9",
+        "@vue/shared": "^3.5.14",
+        "c12": "^3.0.4",
         "chokidar": "^4.0.3",
         "compatx": "^0.2.0",
         "consola": "^3.4.2",
@@ -8924,18 +8947,18 @@
         "mlly": "^1.7.4",
         "mocked-exports": "^0.1.1",
         "nanotar": "^0.2.0",
-        "nitropack": "^2.11.11",
+        "nitropack": "^2.11.12",
         "nypm": "^0.6.0",
         "ofetch": "^1.4.1",
         "ohash": "^2.0.11",
         "on-change": "^5.0.1",
-        "oxc-parser": "^0.69.0",
+        "oxc-parser": "^0.71.0",
         "pathe": "^2.0.3",
         "perfect-debounce": "^1.0.0",
         "pkg-types": "^2.1.0",
         "radix3": "^1.1.2",
         "scule": "^1.3.0",
-        "semver": "^7.7.1",
+        "semver": "^7.7.2",
         "std-env": "^3.9.0",
         "strip-literal": "^3.0.0",
         "tinyglobby": "0.2.13",
@@ -8944,11 +8967,11 @@
         "uncrypto": "^0.1.3",
         "unctx": "^2.4.1",
         "unimport": "^5.0.1",
-        "unplugin": "^2.3.3",
+        "unplugin": "^2.3.4",
         "unplugin-vue-router": "^0.12.0",
         "unstorage": "^1.16.0",
         "untyped": "^2.0.0",
-        "vue": "^3.5.13",
+        "vue": "^3.5.14",
         "vue-bundle-renderer": "^2.1.1",
         "vue-devtools-stub": "^0.1.0",
         "vue-router": "^4.5.1"
@@ -9158,12 +9181,12 @@
       }
     },
     "node_modules/oxc-parser": {
-      "version": "0.69.0",
-      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.69.0.tgz",
-      "integrity": "sha512-6UYcFCyCIoZ2t7gyYdPHxM0BTIjM7Y5MCCTfZ2obVITcLd0lXdkbjVibMBD/qVVG+7cURF7Lw32uykU0YR3QUg==",
+      "version": "0.71.0",
+      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.71.0.tgz",
+      "integrity": "sha512-RXmu7qi+67RJ8E5UhKZJdliTI+AqD3gncsJecjujcYvjsCZV9KNIfu42fQAnAfLaYZuzOMRdUYh7LzV3F1C0Gw==",
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "^0.69.0"
+        "@oxc-project/types": "^0.71.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -9172,19 +9195,20 @@
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxc-parser/binding-darwin-arm64": "0.69.0",
-        "@oxc-parser/binding-darwin-x64": "0.69.0",
-        "@oxc-parser/binding-freebsd-x64": "0.69.0",
-        "@oxc-parser/binding-linux-arm-gnueabihf": "0.69.0",
-        "@oxc-parser/binding-linux-arm64-gnu": "0.69.0",
-        "@oxc-parser/binding-linux-arm64-musl": "0.69.0",
-        "@oxc-parser/binding-linux-riscv64-gnu": "0.69.0",
-        "@oxc-parser/binding-linux-s390x-gnu": "0.69.0",
-        "@oxc-parser/binding-linux-x64-gnu": "0.69.0",
-        "@oxc-parser/binding-linux-x64-musl": "0.69.0",
-        "@oxc-parser/binding-wasm32-wasi": "0.69.0",
-        "@oxc-parser/binding-win32-arm64-msvc": "0.69.0",
-        "@oxc-parser/binding-win32-x64-msvc": "0.69.0"
+        "@oxc-parser/binding-darwin-arm64": "0.71.0",
+        "@oxc-parser/binding-darwin-x64": "0.71.0",
+        "@oxc-parser/binding-freebsd-x64": "0.71.0",
+        "@oxc-parser/binding-linux-arm-gnueabihf": "0.71.0",
+        "@oxc-parser/binding-linux-arm-musleabihf": "0.71.0",
+        "@oxc-parser/binding-linux-arm64-gnu": "0.71.0",
+        "@oxc-parser/binding-linux-arm64-musl": "0.71.0",
+        "@oxc-parser/binding-linux-riscv64-gnu": "0.71.0",
+        "@oxc-parser/binding-linux-s390x-gnu": "0.71.0",
+        "@oxc-parser/binding-linux-x64-gnu": "0.71.0",
+        "@oxc-parser/binding-linux-x64-musl": "0.71.0",
+        "@oxc-parser/binding-wasm32-wasi": "0.71.0",
+        "@oxc-parser/binding-win32-arm64-msvc": "0.71.0",
+        "@oxc-parser/binding-win32-x64-msvc": "0.71.0"
       }
     },
     "node_modules/p-event": {
@@ -11750,9 +11774,9 @@
       }
     },
     "node_modules/tapable": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
-      "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.2.tgz",
+      "integrity": "sha512-Re10+NauLTMCudc7T5WLFLAwDhQ0JWdrMK+9B2M8zR5hRExKmsRDCBA7/aV/pNJFltmBFO5BAMlQFi/vq3nKOg==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -12083,9 +12107,9 @@
       }
     },
     "node_modules/unhead": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/unhead/-/unhead-2.0.8.tgz",
-      "integrity": "sha512-63WR+y08RZE7ChiFdgNY64haAkhCtUS5/HM7xo4Q83NA63txWbEh2WGmrKbArdQmSct+XlqbFN8ZL1yWpQEHEA==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/unhead/-/unhead-2.0.10.tgz",
+      "integrity": "sha512-GT188rzTCeSKt55tYyQlHHKfUTtZvgubrXiwzGeXg6UjcKO3FsagaMzQp6TVDrpDY++3i7Qt0t3pnCc/ebg5yQ==",
       "license": "MIT",
       "dependencies": {
         "hookable": "^5.5.3"
@@ -12594,9 +12618,9 @@
       }
     },
     "node_modules/vite-node": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.1.3.tgz",
-      "integrity": "sha512-uHV4plJ2IxCl4u1up1FQRrqclylKAogbtBfOTwcuJ28xFi+89PZ57BRh+naIRvH70HPwxy5QHYzg1OrEaC7AbA==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.1.4.tgz",
+      "integrity": "sha512-6enNwYnpyDo4hEgytbmc6mYWHXDHYEn0D1/rw4Q+tnHUGtKTJsn8T1YkX6Q18wI5LCrS8CTYlBaiCqxOy2kvUA==",
       "license": "MIT",
       "dependencies": {
         "cac": "^6.7.14",
@@ -12792,16 +12816,16 @@
       "license": "MIT"
     },
     "node_modules/vue": {
-      "version": "3.5.13",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.13.tgz",
-      "integrity": "sha512-wmeiSMxkZCSc+PM2w2VRsOYAZC8GdipNFRTsLSfodVqI9mbejKeXEGr8SckuLnrQPGe3oJN5c3K0vpoU9q/wCQ==",
+      "version": "3.5.15",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.15.tgz",
+      "integrity": "sha512-aD9zK4rB43JAMK/5BmS4LdPiEp8Fdh8P1Ve/XNuMF5YRf78fCyPE6FUbQwcaWQ5oZ1R2CD9NKE0FFOVpMR7gEQ==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.5.13",
-        "@vue/compiler-sfc": "3.5.13",
-        "@vue/runtime-dom": "3.5.13",
-        "@vue/server-renderer": "3.5.13",
-        "@vue/shared": "3.5.13"
+        "@vue/compiler-dom": "3.5.15",
+        "@vue/compiler-sfc": "3.5.15",
+        "@vue/runtime-dom": "3.5.15",
+        "@vue/server-renderer": "3.5.15",
+        "@vue/shared": "3.5.15"
       },
       "peerDependencies": {
         "typescript": "*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kickstart-nuxt-ssr",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": false,
   "repository": {
     "type": "git",
@@ -20,9 +20,9 @@
   "dependencies": {
     "@contentstack/delivery-sdk": "^4.7.0",
     "@contentstack/live-preview-utils": "^3.2.2",
-    "@timbenniks/contentstack-endpoints": "^1.0.9",
+    "@timbenniks/contentstack-endpoints": "^1.0.10",
     "@nuxtjs/tailwindcss": "^6.14.0",
-    "nuxt": "^3.17.3",
+    "nuxt": "^3.17.4",
     "vue": "latest",
     "vue-router": "latest"
   }


### PR DESCRIPTION
- Updated version from 1.0.1 to 1.0.2 in package.json
- Upgraded @timbenniks/contentstack-endpoints from 1.0.9 to 1.0.10
- Upgraded nuxt from 3.17.3 to 3.17.4