### PR TITLE
chore: bump version to 1.1.3 and update dependencies

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,26 +1,26 @@
 {
   "name": "kickstart-nuxt-ssr",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kickstart-nuxt-ssr",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@contentstack/delivery-sdk": "^5.4.0",
+        "@contentstack/delivery-sdk": "^5.5.0",
         "@contentstack/live-preview-utils": "^4.4.5",
         "@contentstack/utils": "^1.9.1",
         "@nuxtjs/tailwindcss": "^6.14.0",
-        "nuxt": "^4.5.0",
+        "nuxt": "^4.5.1",
         "vue": "^3.5.40",
         "vue-router": "^5.2.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-linux-x64-gnu": "^4.62.2",
-        "@rollup/rollup-linux-x64-musl": "^4.62.2"
+        "@rollup/rollup-linux-x64-gnu": "^4.62.3",
+        "@rollup/rollup-linux-x64-musl": "^4.62.3"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -520,9 +520,9 @@
       }
     },
     "node_modules/@contentstack/delivery-sdk": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@contentstack/delivery-sdk/-/delivery-sdk-5.4.0.tgz",
-      "integrity": "sha512-TqU2TMBGcpmxry/w00m1uL7gYENCxZHIR8GD0hwfl+d+bZbCrI9/AIz+verdjf4piJ9xGexN0N7ZHSOaTHq5Qg==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@contentstack/delivery-sdk/-/delivery-sdk-5.5.0.tgz",
+      "integrity": "sha512-X6inqsDh0Bcz6YO3QhN+H7TPiZ9PNx31DsVOWP+w4T5ohPqM2EYh53rbl6gOXQG9JJ9ihpDzdoQRcM4ld2Vglw==",
       "license": "MIT",
       "dependencies": {
         "@contentstack/core": "^1.4.1",
@@ -621,27 +621,65 @@
         "postcss-selector-parser": "^7.0.0"
       }
     },
+    "node_modules/@devframes/hub": {
+      "version": "0.7.15",
+      "resolved": "https://registry.npmjs.org/@devframes/hub/-/hub-0.7.15.tgz",
+      "integrity": "sha512-g2aUJZAsmBsWARqvA2nhT5F9v2usJ/uiavstsWA7FZaXU6+2LYx/OafqDlFNUa+PxGUWwEZe/qzwAuRoZjv8uA==",
+      "license": "MIT",
+      "dependencies": {
+        "birpc": "^4.0.0",
+        "destr": "^2.0.5",
+        "nostics": "^1.2.0",
+        "pathe": "^2.0.3",
+        "perfect-debounce": "^2.1.0",
+        "tinyexec": "^1.2.4",
+        "zigpty": "^0.2.1"
+      },
+      "peerDependencies": {
+        "devframe": "0.7.15"
+      }
+    },
+    "node_modules/@devframes/json-render": {
+      "version": "0.7.15",
+      "resolved": "https://registry.npmjs.org/@devframes/json-render/-/json-render-0.7.15.tgz",
+      "integrity": "sha512-IB1EsAHKK313yuslrEyAl7z6347YeV+eT5EtNQwjLcoYh1sD6er/eqdj4Aeicovpg49U7tmlFZHicDxVl1W89A==",
+      "license": "MIT",
+      "dependencies": {
+        "@json-render/core": "^0.19.0",
+        "nostics": "^1.2.0",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@devframes/hub": "0.7.15",
+        "devframe": "0.7.15"
+      },
+      "peerDependenciesMeta": {
+        "@devframes/hub": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@dxup/nuxt": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@dxup/nuxt/-/nuxt-0.5.3.tgz",
-      "integrity": "sha512-PRwX3kEDjZF4t+j+lWbhFSZ1WBklwFSus5byNtkCL2PgWoUMbywNtewJcUHVSOQdwEYsbD1H/md3e/CKaTvDyw==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@dxup/nuxt/-/nuxt-0.5.5.tgz",
+      "integrity": "sha512-7GIUr0aD4klOyLjGMzLBNjsZiIbU6EPqO5de1Q1kTPdZXWMqamr5FqRCZycA/9n9lxsXRLFxENL7tcRAClMTrw==",
       "license": "MIT",
       "dependencies": {
         "@dxup/unimport": "^0.1.2",
-        "@nuxt/kit": "^4.4.8",
-        "@vue/compiler-dom": "^3.5.39",
+        "@nuxt/kit": "^4.5.0",
+        "@vue/compiler-dom": "^3.5.40",
         "chokidar": "^5.0.0",
         "knitwork": "^1.3.0",
-        "magic-string": "^0.30.21",
+        "magic-string": "^1.1.0",
         "pathe": "^2.0.3",
         "tinyglobby": "^0.2.17",
         "unplugin": "^3.3.0"
       }
     },
     "node_modules/@dxup/nuxt/node_modules/@nuxt/kit": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-4.5.0.tgz",
-      "integrity": "sha512-VD4GjRjbh7r7ILoXYbiKeQgZuYP/vJ7iMk6fSRak1+xEyXHpQ+OIq/EfIjfsHv7DVimddOB+I6W/wGXjRVZ+Ng==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-4.5.1.tgz",
+      "integrity": "sha512-xDXQspE2blxaZwxwGknL/BqaIbkLizl85Ov+pbSlPPd/rw2KjJGx88RHU5SwoQNwCiSC5hWZBnVAznIsq1xNHQ==",
       "license": "MIT",
       "dependencies": {
         "c12": "^3.3.4",
@@ -654,29 +692,20 @@
         "jiti": "^2.7.0",
         "klona": "^2.0.6",
         "mlly": "^1.8.2",
-        "nostics": "^1.1.4",
+        "nostics": "^1.2.0",
         "ohash": "^2.0.11",
         "pathe": "^2.0.3",
         "pkg-types": "^2.3.1",
         "rc9": "^3.0.1",
         "scule": "^1.3.0",
-        "semver": "^7.8.5",
         "tinyglobby": "^0.2.17",
         "ufo": "^1.6.4",
         "unctx": "^3.0.0",
-        "untyped": "^2.0.0"
+        "untyped": "^2.0.0",
+        "verkit": "^0.2.0"
       },
       "engines": {
         "node": ">=18.12.0"
-      }
-    },
-    "node_modules/@dxup/nuxt/node_modules/magic-string": {
-      "version": "0.30.21",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
-      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/@dxup/nuxt/node_modules/unctx": {
@@ -1413,21 +1442,24 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
-      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.1.tgz",
+      "integrity": "sha512-KjZdi8Q1wh89gsVmghvbrMgWl6ZWmRmHV6wjB7/g4Zf0dyO+hH3neZUtuDNPO00qq5YE5RITVWvrIZKRaAmzGQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@tybys/wasm-util": "^0.10.3"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Brooooooklyn"
       },
       "peerDependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1"
+        "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.3",
+        "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.3"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -1525,43 +1557,44 @@
       "license": "MIT"
     },
     "node_modules/@nuxt/devtools": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@nuxt/devtools/-/devtools-3.2.4.tgz",
-      "integrity": "sha512-VPbFy7hlPzWpEZk4BsuVpNuHq1ZYGV9xezjb7/NGuePuNLqeNn74YZugU+PCtva7OwKhEeTXmMK0Mqo/6+nwNA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@nuxt/devtools/-/devtools-3.4.0.tgz",
+      "integrity": "sha512-hOOpXnNyGf03ac0TIqZQK5ErlX2zTB6nPcf6SxLBG9IW/oCECM5JQEgI4EyqDLE2VjkXaalOUdl0BwtL2XuEMw==",
       "license": "MIT",
       "dependencies": {
-        "@nuxt/devtools-kit": "3.2.4",
-        "@nuxt/devtools-wizard": "3.2.4",
-        "@nuxt/kit": "^4.4.2",
-        "@vue/devtools-core": "^8.1.0",
-        "@vue/devtools-kit": "^8.1.0",
+        "@nuxt/devtools-kit": "3.4.0",
+        "@nuxt/devtools-wizard": "3.4.0",
+        "@nuxt/kit": "^4.4.4",
+        "@vue/devtools-core": "^8.1.1",
+        "@vue/devtools-kit": "^8.1.1",
         "birpc": "^4.0.0",
         "consola": "^3.4.2",
         "destr": "^2.0.5",
         "error-stack-parser-es": "^1.0.5",
         "execa": "^8.0.1",
-        "fast-npm-meta": "^1.4.2",
+        "fast-npm-meta": "^1.5.0",
         "get-port-please": "^3.2.0",
-        "hookable": "^6.1.0",
+        "hookable": "^6.1.1",
         "image-meta": "^0.2.2",
         "is-installed-globally": "^1.0.0",
-        "launch-editor": "^2.13.1",
+        "launch-editor": "^2.13.2",
         "local-pkg": "^1.1.2",
         "magicast": "^0.5.2",
-        "nypm": "^0.6.5",
+        "nypm": "^0.6.6",
         "ohash": "^2.0.11",
         "pathe": "^2.0.3",
         "perfect-debounce": "^2.1.0",
-        "pkg-types": "^2.3.0",
+        "pkg-types": "^2.3.1",
         "semver": "^7.7.4",
-        "simple-git": "^3.33.0",
+        "simple-git": "^3.36.0",
         "sirv": "^3.0.2",
-        "structured-clone-es": "^2.0.0",
-        "tinyglobby": "^0.2.15",
+        "structured-clone-es": "^2.0.1",
+        "tinyglobby": "^0.2.16",
+        "unstorage": "^1.17.5",
         "vite-plugin-inspect": "^11.3.3",
         "vite-plugin-vue-tracer": "^1.3.0",
         "which": "^6.0.1",
-        "ws": "^8.19.0"
+        "ws": "^8.20.0"
       },
       "bin": {
         "devtools": "cli.mjs"
@@ -1577,12 +1610,12 @@
       }
     },
     "node_modules/@nuxt/devtools-kit": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@nuxt/devtools-kit/-/devtools-kit-3.2.4.tgz",
-      "integrity": "sha512-Yxy2Xgmq5hf3dQy983V0xh0OJV2mYwRZz9eVIGc3EaribdFGPDNGMMbYqX9qCty3Pbxn/bCF3J0UyPaNlHVayQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@nuxt/devtools-kit/-/devtools-kit-3.4.0.tgz",
+      "integrity": "sha512-gkLbWT6xJ3QztuVuhDVZRWgZOhcbyhmyxEv92THTlgrmijJRWiRghw7a0fubPVwy5TZfinQaRH3hb1QDGTei1g==",
       "license": "MIT",
       "dependencies": {
-        "@nuxt/kit": "^4.4.2",
+        "@nuxt/kit": "^4.4.4",
         "execa": "^8.0.1"
       },
       "peerDependencies": {
@@ -1590,9 +1623,9 @@
       }
     },
     "node_modules/@nuxt/devtools-kit/node_modules/@nuxt/kit": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-4.5.0.tgz",
-      "integrity": "sha512-VD4GjRjbh7r7ILoXYbiKeQgZuYP/vJ7iMk6fSRak1+xEyXHpQ+OIq/EfIjfsHv7DVimddOB+I6W/wGXjRVZ+Ng==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-4.5.1.tgz",
+      "integrity": "sha512-xDXQspE2blxaZwxwGknL/BqaIbkLizl85Ov+pbSlPPd/rw2KjJGx88RHU5SwoQNwCiSC5hWZBnVAznIsq1xNHQ==",
       "license": "MIT",
       "dependencies": {
         "c12": "^3.3.4",
@@ -1605,17 +1638,17 @@
         "jiti": "^2.7.0",
         "klona": "^2.0.6",
         "mlly": "^1.8.2",
-        "nostics": "^1.1.4",
+        "nostics": "^1.2.0",
         "ohash": "^2.0.11",
         "pathe": "^2.0.3",
         "pkg-types": "^2.3.1",
         "rc9": "^3.0.1",
         "scule": "^1.3.0",
-        "semver": "^7.8.5",
         "tinyglobby": "^0.2.17",
         "ufo": "^1.6.4",
         "unctx": "^3.0.0",
-        "untyped": "^2.0.0"
+        "untyped": "^2.0.0",
+        "verkit": "^0.2.0"
       },
       "engines": {
         "node": ">=18.12.0"
@@ -1648,18 +1681,18 @@
       }
     },
     "node_modules/@nuxt/devtools-wizard": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@nuxt/devtools-wizard/-/devtools-wizard-3.2.4.tgz",
-      "integrity": "sha512-5tu2+Quu9XTxwtpzM8CUN0UKn/bzZIfJcoGd+at5Yy1RiUQJ4E52tRK0idW1rMSUDkbkvX3dSnu8Tpj7SAtWdQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@nuxt/devtools-wizard/-/devtools-wizard-3.4.0.tgz",
+      "integrity": "sha512-BIaNM0Aig9j6lafF75+dHZ9sCdEbLv4ncwpVsVOF6N6z1ALvCesCCaTnhON+6MIf2hYDcSiC/zL/VhGjFkWV4A==",
       "license": "MIT",
       "dependencies": {
-        "@clack/prompts": "^1.1.0",
+        "@clack/prompts": "^1.3.0",
         "consola": "^3.4.2",
-        "diff": "^8.0.3",
+        "diff": "^8.0.4",
         "execa": "^8.0.1",
         "magicast": "^0.5.2",
         "pathe": "^2.0.3",
-        "pkg-types": "^2.3.0",
+        "pkg-types": "^2.3.1",
         "semver": "^7.7.4"
       },
       "bin": {
@@ -1667,9 +1700,9 @@
       }
     },
     "node_modules/@nuxt/devtools/node_modules/@nuxt/kit": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-4.5.0.tgz",
-      "integrity": "sha512-VD4GjRjbh7r7ILoXYbiKeQgZuYP/vJ7iMk6fSRak1+xEyXHpQ+OIq/EfIjfsHv7DVimddOB+I6W/wGXjRVZ+Ng==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-4.5.1.tgz",
+      "integrity": "sha512-xDXQspE2blxaZwxwGknL/BqaIbkLizl85Ov+pbSlPPd/rw2KjJGx88RHU5SwoQNwCiSC5hWZBnVAznIsq1xNHQ==",
       "license": "MIT",
       "dependencies": {
         "c12": "^3.3.4",
@@ -1682,17 +1715,17 @@
         "jiti": "^2.7.0",
         "klona": "^2.0.6",
         "mlly": "^1.8.2",
-        "nostics": "^1.1.4",
+        "nostics": "^1.2.0",
         "ohash": "^2.0.11",
         "pathe": "^2.0.3",
         "pkg-types": "^2.3.1",
         "rc9": "^3.0.1",
         "scule": "^1.3.0",
-        "semver": "^7.8.5",
         "tinyglobby": "^0.2.17",
         "ufo": "^1.6.4",
         "unctx": "^3.0.0",
-        "untyped": "^2.0.0"
+        "untyped": "^2.0.0",
+        "verkit": "^0.2.0"
       },
       "engines": {
         "node": ">=18.12.0"
@@ -1725,9 +1758,9 @@
       }
     },
     "node_modules/@nuxt/kit": {
-      "version": "3.21.9",
-      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.21.9.tgz",
-      "integrity": "sha512-SJ3W7INBJLwnmFQPm2BACiqS25enc6QIm87aLQCcxo/TFtRnWanYtgDdwyHqUHgOAGmq9pYjgk83B2bpBKnDTw==",
+      "version": "3.21.10",
+      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.21.10.tgz",
+      "integrity": "sha512-zs1+BZlRK1VlHo37TTzaMXQ+SemS1WeGRtcjWbW1ZoXpL3/ctn2VQu6nFpu6JqsJRd0QAPNS4GYmxGwLK8EHNw==",
       "license": "MIT",
       "dependencies": {
         "c12": "^3.3.4",
@@ -1757,28 +1790,28 @@
       }
     },
     "node_modules/@nuxt/nitro-server": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@nuxt/nitro-server/-/nitro-server-4.5.0.tgz",
-      "integrity": "sha512-XxLtFxBLJkXJ368mzgub7eDMc9I4pwnZhN9gX8UTzajgoEnbxPhmUl7xG8RVBMovQ2FOFjAph2kwJrnlMNX/cw==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@nuxt/nitro-server/-/nitro-server-4.5.1.tgz",
+      "integrity": "sha512-bYg+Rri9qLNiNnK70mvdghwwWtOEvlvBn3BnnEZWEFM8A51zM803Ltg+TwR6B6/1jdYOdZ6cnso4pvpCJuPlww==",
       "license": "MIT",
       "dependencies": {
         "@nuxt/devalue": "^2.0.2",
-        "@nuxt/kit": "4.5.0",
-        "@unhead/vue": "^3.1.8",
-        "@vue/shared": "^3.5.39",
+        "@nuxt/kit": "4.5.1",
+        "@unhead/vue": "^3.2.3",
+        "@vue/shared": "^3.5.40",
         "consola": "^3.4.2",
         "defu": "^6.1.7",
         "destr": "^2.0.5",
-        "devalue": "^5.8.1",
+        "devalue": "^5.8.2",
         "errx": "^0.1.0",
         "escape-string-regexp": "^5.0.0",
         "exsolve": "^1.1.0",
         "h3": "^1.15.11",
-        "impound": "^1.1.5",
+        "impound": "^1.1.6",
         "klona": "^2.0.6",
         "mocked-exports": "^0.1.1",
         "nitropack": "^2.13.4",
-        "nostics": "^1.1.4",
+        "nostics": "^1.2.0",
         "nypm": "^0.6.8",
         "ohash": "^2.0.11",
         "pathe": "^2.0.3",
@@ -1787,7 +1820,7 @@
         "ufo": "^1.6.4",
         "unctx": "^3.0.0",
         "unstorage": "^1.17.5",
-        "vue": "^3.5.39",
+        "vue": "^3.5.40",
         "vue-bundle-renderer": "^2.3.1",
         "vue-devtools-stub": "^0.1.0"
       },
@@ -1798,7 +1831,7 @@
         "@babel/plugin-proposal-decorators": "^7.25.0 || ^8.0.0",
         "@babel/plugin-syntax-typescript": "^7.25.0 || ^8.0.0",
         "@rollup/plugin-babel": "^6.0.0 || ^7.0.0",
-        "nuxt": "^4.5.0"
+        "nuxt": "^4.5.1"
       },
       "peerDependenciesMeta": {
         "@babel/plugin-proposal-decorators": {
@@ -1813,9 +1846,9 @@
       }
     },
     "node_modules/@nuxt/nitro-server/node_modules/@nuxt/kit": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-4.5.0.tgz",
-      "integrity": "sha512-VD4GjRjbh7r7ILoXYbiKeQgZuYP/vJ7iMk6fSRak1+xEyXHpQ+OIq/EfIjfsHv7DVimddOB+I6W/wGXjRVZ+Ng==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-4.5.1.tgz",
+      "integrity": "sha512-xDXQspE2blxaZwxwGknL/BqaIbkLizl85Ov+pbSlPPd/rw2KjJGx88RHU5SwoQNwCiSC5hWZBnVAznIsq1xNHQ==",
       "license": "MIT",
       "dependencies": {
         "c12": "^3.3.4",
@@ -1828,17 +1861,17 @@
         "jiti": "^2.7.0",
         "klona": "^2.0.6",
         "mlly": "^1.8.2",
-        "nostics": "^1.1.4",
+        "nostics": "^1.2.0",
         "ohash": "^2.0.11",
         "pathe": "^2.0.3",
         "pkg-types": "^2.3.1",
         "rc9": "^3.0.1",
         "scule": "^1.3.0",
-        "semver": "^7.8.5",
         "tinyglobby": "^0.2.17",
         "ufo": "^1.6.4",
         "unctx": "^3.0.0",
-        "untyped": "^2.0.0"
+        "untyped": "^2.0.0",
+        "verkit": "^0.2.0"
       },
       "engines": {
         "node": ">=18.12.0"
@@ -1871,14 +1904,14 @@
       }
     },
     "node_modules/@nuxt/schema": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@nuxt/schema/-/schema-4.5.0.tgz",
-      "integrity": "sha512-RY4cH0z2JRlmcsAIrBBXlmRW8FnCBTRdHCByttog+lAxg1hrJ2W5OdnoHO0KMeZSJg67MdeYPOZu7ZszFEymgA==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@nuxt/schema/-/schema-4.5.1.tgz",
+      "integrity": "sha512-RDdu0BBg9y+Eiyu95LUDJ57YrejJ5v1/VA2r5oBLYiiSiLrlVt33HN9ut4qSyUN8gRTOXnFADery8AyJpTjdWA==",
       "license": "MIT",
       "dependencies": {
-        "@vue/shared": "^3.5.39",
+        "@vue/shared": "^3.5.40",
         "defu": "^6.1.7",
-        "nostics": "^1.1.4",
+        "nostics": "^1.2.0",
         "pathe": "^2.0.3",
         "pkg-types": "^2.3.1",
         "std-env": "^4.2.0"
@@ -1916,20 +1949,21 @@
       "license": "MIT"
     },
     "node_modules/@nuxt/vite-builder": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@nuxt/vite-builder/-/vite-builder-4.5.0.tgz",
-      "integrity": "sha512-j57djn164gnTIFMw0ISMMesX6a98H51XKoERm90401Prb4VERq0ULNb8zOXrHgJMGFOy6An7tKo8fD/J7qCLLA==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@nuxt/vite-builder/-/vite-builder-4.5.1.tgz",
+      "integrity": "sha512-gHMqCZ4Fd9lvJ6FUh9qyzD5Sdx0UyM1pxV+wzjlQvBbX4NxvB16spMcNGUUnnV6nX2so3JJROXxghlKf7Uj6nw==",
       "license": "MIT",
       "dependencies": {
-        "@nuxt/kit": "4.5.0",
+        "@nuxt/kit": "4.5.1",
         "@vitejs/plugin-vue": "^6.0.8",
         "@vitejs/plugin-vue-jsx": "^5.1.6",
-        "autoprefixer": "^10.5.3",
+        "autoprefixer": "^10.5.4",
         "consola": "^3.4.2",
         "cssnano": "^8.0.2",
         "defu": "^6.1.7",
         "escape-string-regexp": "^5.0.0",
         "exsolve": "^1.1.0",
+        "generic-names": "^4.0.0",
         "get-port-please": "^3.2.0",
         "jiti": "^2.7.0",
         "js-tokens": "^10.0.0",
@@ -1939,15 +1973,15 @@
         "nypm": "^0.6.8",
         "pathe": "^2.0.3",
         "pkg-types": "^2.3.1",
-        "postcss": "^8.5.19",
-        "rolldown-string": "^0.3.0",
-        "seroval": "^1.5.5",
+        "postcss": "^8.5.22",
+        "rolldown-string": "^0.3.1",
+        "seroval": "^1.5.6",
         "std-env": "^4.2.0",
         "ufo": "^1.6.4",
         "unenv": "^2.0.0-rc.24",
-        "vite": "^8.1.4",
+        "vite": "^8.1.5",
         "vite-node": "^6.0.0",
-        "vite-plugin-checker": "^0.14.4",
+        "vite-plugin-checker": "^0.14.5",
         "vue-bundle-renderer": "^2.3.1"
       },
       "engines": {
@@ -1956,7 +1990,7 @@
       "peerDependencies": {
         "@babel/plugin-proposal-decorators": "^7.25.0 || ^8.0.0",
         "@babel/plugin-syntax-jsx": "^7.25.0 || ^8.0.0",
-        "nuxt": "4.5.0",
+        "nuxt": "4.5.1",
         "rolldown": "^1.0.0",
         "rollup-plugin-visualizer": "^6.0.0 || ^7.0.1",
         "vue": "^3.3.4"
@@ -1977,9 +2011,9 @@
       }
     },
     "node_modules/@nuxt/vite-builder/node_modules/@nuxt/kit": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-4.5.0.tgz",
-      "integrity": "sha512-VD4GjRjbh7r7ILoXYbiKeQgZuYP/vJ7iMk6fSRak1+xEyXHpQ+OIq/EfIjfsHv7DVimddOB+I6W/wGXjRVZ+Ng==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-4.5.1.tgz",
+      "integrity": "sha512-xDXQspE2blxaZwxwGknL/BqaIbkLizl85Ov+pbSlPPd/rw2KjJGx88RHU5SwoQNwCiSC5hWZBnVAznIsq1xNHQ==",
       "license": "MIT",
       "dependencies": {
         "c12": "^3.3.4",
@@ -1992,17 +2026,17 @@
         "jiti": "^2.7.0",
         "klona": "^2.0.6",
         "mlly": "^1.8.2",
-        "nostics": "^1.1.4",
+        "nostics": "^1.2.0",
         "ohash": "^2.0.11",
         "pathe": "^2.0.3",
         "pkg-types": "^2.3.1",
         "rc9": "^3.0.1",
         "scule": "^1.3.0",
-        "semver": "^7.8.5",
         "tinyglobby": "^0.2.17",
         "ufo": "^1.6.4",
         "unctx": "^3.0.0",
-        "untyped": "^2.0.0"
+        "untyped": "^2.0.0",
+        "verkit": "^0.2.0"
       },
       "engines": {
         "node": ">=18.12.0"
@@ -2479,9 +2513,9 @@
       }
     },
     "node_modules/@preact/signals": {
-      "version": "2.9.4",
-      "resolved": "https://registry.npmjs.org/@preact/signals/-/signals-2.9.4.tgz",
-      "integrity": "sha512-JzAZXcRkmCNf9wVuxNI7UWseu3++Mm0dZ6UFyjFby44CyKIl7Y06oOsW3KA5Nx0L8tpE87OY5pLe0uQ0xcWKrg==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@preact/signals/-/signals-2.10.0.tgz",
+      "integrity": "sha512-avH1zQLZR6c0DmH3pT/sn4RIzsNDXAue+MEoyS5RIvApKALSU8m05KyBOL8ua21gxeDYp1DclTMcFd+N1zaL1Q==",
       "license": "MIT",
       "dependencies": {
         "@preact/signals-core": "^1.14.4"
@@ -2505,9 +2539,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.0.tgz",
-      "integrity": "sha512-9yB1l95IrJuNGDFdOYe79vdApdz6WWBCObE+rQ2LUliYUlcyFwSYIb2xb5/Ifw7dAtMy2ZqNyd8QTSOc7duAKw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.1.tgz",
+      "integrity": "sha512-02hOeOSryYxVrOIphmLAsqnCJWxwlzFk+pEt/N/i6OgT3lShHO7xGCU5cpgchRDHboAEbSjzgGh+O/u1GswQmA==",
       "cpu": [
         "arm64"
       ],
@@ -2521,9 +2555,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.0.tgz",
-      "integrity": "sha512-pexNaW9ACLUOaBITOpU6qVu4VrsOFIjTv6bzgu0YUATo4eUJx0V605PxwZfndpPOn0ilqGqvGQ0M8UW0IE24jg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.1.tgz",
+      "integrity": "sha512-fMsTOnN0OjFm3CyppWPitKnc8UlliVARUULW6cfU6AIqjdtgmSFWSk9vecHzZduv/yMWIHDlRhM1e8Iff9uAfA==",
       "cpu": [
         "arm64"
       ],
@@ -2537,9 +2571,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.0.tgz",
-      "integrity": "sha512-NqKYaq0355ZmNMG4QGpxtEDxsc7tGDhjhCm4PpE0cwnBW+5Il95LJyq414niEiaKLVjnVHBEjSo1wngKxJNiFw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.1.tgz",
+      "integrity": "sha512-1wjKdz/XLGKHaTNHjQveQ/B23TKx4ItAqm1JbyVuvNPc4Ze0Fb48s49TAd/2zcplPl8okE/UbTgmlVfwT7eFeQ==",
       "cpu": [
         "x64"
       ],
@@ -2553,9 +2587,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.0.tgz",
-      "integrity": "sha512-3vPoHzh6eBTz9IbB0/qZdSr0Qeks2echn+I4cHu2joV74VriPDdldswksEDzrl1mBB+oPRi+67+3Ib59paxIPQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.1.tgz",
+      "integrity": "sha512-Fa0jHR07E7YBN4vOEsbVf2briYNsuOowfLJaXULZM0ldMlaCaj2LJgLMbMe4iacRyZmvR8efFhgR9wKuGclQUg==",
       "cpu": [
         "x64"
       ],
@@ -2569,9 +2603,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.0.tgz",
-      "integrity": "sha512-E6NNefZ1bUVmKJq2tJkf45J4Zyczj7qm9rUT7NY+Xo2474Y13qWAwc2tvBt0BAVbmtXR1llkxXg0Ou1jbDf2SQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.1.tgz",
+      "integrity": "sha512-pzkgu1SSHGgRRyRZ4fbmSgmajbVt+epaLP99NDjFft69v/ypfTi6swBMiVdh2EkQ0OSnHE1lZDM7DRGkyAzUpA==",
       "cpu": [
         "arm"
       ],
@@ -2585,9 +2619,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.0.tgz",
-      "integrity": "sha512-D+TgkdgM1vu+7/Fpf8+v0ARW+RXEP9Ccazgm8zQ4JFFd9Q7SrYQ2TakU5S5ihazQDgpKyAgZDOcIFsvoHmTZ8w==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.1.tgz",
+      "integrity": "sha512-QI5SEDY8cbiYWHx0VO4vIc3UlS6a32vXHjU8Qy/17adEmZIPuByJg13UEvo9c/UCiUkdcVWY83C+b+JrwnNyUg==",
       "cpu": [
         "arm64"
       ],
@@ -2601,9 +2635,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.0.tgz",
-      "integrity": "sha512-wUqdwJBbAv0APN87GecstdMUtLjjNTs0hBALpxETD73mccFxdmt/XeizXDtN5RAlBwNKmI+Tg+blect2G+8IeQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.1.tgz",
+      "integrity": "sha512-Sm41FyCeXqmYcERoYOCbGIL5hNfd8w9LQ7Y61Bev48HkcjaJqV/iiVOaiDxjVTRMS+QKrZmD8cfPt4uMVnvM+A==",
       "cpu": [
         "arm64"
       ],
@@ -2617,9 +2651,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.0.tgz",
-      "integrity": "sha512-9DtF35qR9/NrfhM4oxLplCzVVjE+KKm8Pjemi0i/sdhAWkUasjmSo8WTTubNJClhSHCfyk2yeyoXDQEDPtDAAw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.1.tgz",
+      "integrity": "sha512-2x+WhXTGl9yJYPbltW/BSEPTVz9OIWQyER4N+gJEDWkkn904eRcBzELqh/Hf7K0w/ubGbKNMv0ZC+94QK/IFEg==",
       "cpu": [
         "ppc64"
       ],
@@ -2633,9 +2667,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.0.tgz",
-      "integrity": "sha512-RzuHrBh8X8Hntd2N4VR02QGEciq/9JhcZoTpR/Cee6otRrlILGCf3cg2ygHuih+ZebUnWmMrDX6ITI85btO6rQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.1.tgz",
+      "integrity": "sha512-eEjmQpuRQayHPWWnywaWHkFT3ToPbP3RYy42VVd/B9aBGDA+Ol25EIWHxKQST3IiWJjikCWUF7KtbfqwZrzVwQ==",
       "cpu": [
         "s390x"
       ],
@@ -2649,9 +2683,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.0.tgz",
-      "integrity": "sha512-MK7L0018jjh1jR3mh21G2j1zAVcpscJBlPo2z19pRjv2XOYGRhaV4LyiD8HO6nCDdZln9IFgCMIV5yt4E3klGQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.1.tgz",
+      "integrity": "sha512-/Orga1fZYkLc/56jBICcHrKchl8Z2UKdDSr3LG9ToWO1lQ6a4Livk9Xz+9WN91zsz5QR3XQz2NNoSDEvP6qadw==",
       "cpu": [
         "x64"
       ],
@@ -2665,9 +2699,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.0.tgz",
-      "integrity": "sha512-gyrxLQ9NfGb/9LoVnC4kb9miUghw1mghnkfYvNHSnVIXriabnfgGPUP4RLcJm87q3KgYz4FYUG8IDiWUT+CpSw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.1.tgz",
+      "integrity": "sha512-xxBJRL+0q0Kce7orznGWLuylHDY65vuARXZRpX+hPdv+DqK2c3NlCsVA98tlWzWNEE7yPqA/1NQ5nnCrj49Y5A==",
       "cpu": [
         "x64"
       ],
@@ -2681,9 +2715,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.0.tgz",
-      "integrity": "sha512-/6VFMQGRmrhP77KXDC+StIxGzcNp5JOIyYtw0CQ8gPlzhpiIRucYfoM5FaFamHd5BJYIdH86yfP46l1p3WdrFA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.1.tgz",
+      "integrity": "sha512-M6AdXIXw3s+/8XpKMzdGDEXGS1S7kwUsy+rcTIUIOx5Ge4nXKCtAFHFV9YKkXvGcC5WMoTjAteLzlsQROVI0Yw==",
       "cpu": [
         "arm64"
       ],
@@ -2697,27 +2731,55 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.2.0.tgz",
-      "integrity": "sha512-rwdbUL465kisF24WEJLvP3JrEG6E5GRuIHt5wpMwHGERtHe4Wm2CIvtf5gTBgr2tGOHKh5NdKEAFS2VkOPE91g==",
-      "cpu": [
-        "wasm32"
-      ],
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.2.1.tgz",
+      "integrity": "sha512-/TX0SoRGojHzSAHpfVBbavRVSazg5U3h3Y3VXfcc0cdugq6kxdqw8LPGFiPr+/7gE/60zRcsOY2Vi9b9eT0jww==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "1.11.2",
-        "@emnapi/runtime": "1.11.2",
-        "@napi-rs/wasm-runtime": "^1.1.6"
+        "@emnapi/core": "2.0.0-alpha.3",
+        "@emnapi/runtime": "2.0.0-alpha.3",
+        "@napi-rs/wasm-runtime": "^1.2.0"
       },
       "engines": {
-        "node": "^20.19.0 || >=22.12.0"
+        "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "2.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-2.0.0-alpha.3.tgz",
+      "integrity": "sha512-AZypUeJ/yByuxyS7BlSNRDOMLMlROYtjYdIAuBmJssVz1UJDSeYxLrdizhXCFYhedC5bqd/ASy8EuNXbVVXp9g==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "2.0.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "2.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-2.0.0-alpha.3.tgz",
+      "integrity": "sha512-hFPAhMUjJD9BSyCANEISPOogeXC9Zo9ZQl7L6vKnaVsMkCtzznaW/naYypeyl0Gv5rYfWYsZbpixTMpjDJzQeA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-2.0.1.tgz",
+      "integrity": "sha512-9DsSk+o5NBX0CCJT8s0EROGSGxjR/tKu6aBTaVyq+SjAEQH4XcdcRxPBRzsBLizTTJ49MJjF+jgu3qnO9GLQcQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.0.tgz",
-      "integrity": "sha512-+5suHwRiKGmhwyUaNT8a5QbrBvLFh2DbO910TEmGRH1aSxwrCezodvGQnulv4uiWEIv1Kq4ypRsJ5+O+ry1DiA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.1.tgz",
+      "integrity": "sha512-EvRrivJieyHG+AO9lleZWgq+g0+S7oV2C51yuqlcyU/R9net+sI4Pj0F+lUoP2bEr6TWX3SqFaaS0SzfLxSzkw==",
       "cpu": [
         "arm64"
       ],
@@ -2731,9 +2793,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.0.tgz",
-      "integrity": "sha512-WfFv6/qGufotqBSBzBYwgpCkJBk8Nj7697LL9vTz/XWc67e0r3oewu8iMRwQj3AUL45GVD7wVsPjCsAAtW66Wg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.1.tgz",
+      "integrity": "sha512-Z4eCmn5QJ/5+azF9knpLWKfVd9aidn0mAe9TpJgvBLId9Ax3t0+JVxBmT25Bv7NBbVW1TZyKjQjQReouMeH5UQ==",
       "cpu": [
         "x64"
       ],
@@ -2954,9 +3016,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
-      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.3.tgz",
+      "integrity": "sha512-c0wdcekXtQvvn5Tsrk/+op/gUArrbWaFduBnTLP2l1cKLSQs4diMWjJw3m6A0DdzT8dAAX95KpkJ3qynCePbmw==",
       "cpu": [
         "arm"
       ],
@@ -2967,9 +3029,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
-      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.3.tgz",
+      "integrity": "sha512-3YjElDdWN+qXAFbJ/CzPV+0wspLqh54k/I6GfdYtEJRqg7buSgc1yPM3B+93j1M4neobtkATHZTmxK2AMVGfnA==",
       "cpu": [
         "arm64"
       ],
@@ -2980,9 +3042,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
-      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.3.tgz",
+      "integrity": "sha512-Pch2pFNOxxz1hTjypIdPyRTR6riiwRl84+VcN9djS680fw+Co1nAJINrdpqp7KV0NvyuU8ilZXZCjd7ykJl1GQ==",
       "cpu": [
         "arm64"
       ],
@@ -2993,9 +3055,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
-      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.3.tgz",
+      "integrity": "sha512-LEuncFUHFiF8t4yZVZvvZA1wk0pjAscRnsrn1EfTEmN4HXotBi2YtcnLRyaK6UbuczW7xZS5ES+81Rdz8Z0T6g==",
       "cpu": [
         "x64"
       ],
@@ -3006,9 +3068,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
-      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.3.tgz",
+      "integrity": "sha512-zvBUvsQUpOWALdDsk6qbS8bXf2VxmPisuudNDrY7x0p0jBdsoZl8HsHczIOgkQiZldmcacMKtBzpoGVNeIe2bQ==",
       "cpu": [
         "arm64"
       ],
@@ -3019,9 +3081,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
-      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.3.tgz",
+      "integrity": "sha512-C2KmNrcSem/AMg984H/dev+si0lieQGdXdR/lYGJnuumXnFb9Y7QdiI62obFdLlxRYLBv4P0eUVIDbD4c1vVvw==",
       "cpu": [
         "x64"
       ],
@@ -3032,9 +3094,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
-      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.3.tgz",
+      "integrity": "sha512-ggXnsTAEzNQx74XpunRsiZ9aBZDsI7XIa0hm2nzR9f4WzH5/f/d73ZSDaC5ejJ8YLY4NW+V3wr0tjOaeCq8hqA==",
       "cpu": [
         "arm"
       ],
@@ -3045,9 +3107,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
-      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.3.tgz",
+      "integrity": "sha512-2vng+FlzNUhKZxtej3IUqJgbZoQk2M/dwQM20+ULV0R/E/8tr9/P6uEf2iiGIk4HL0zMKh5Jry7mUHdUOvyGgA==",
       "cpu": [
         "arm"
       ],
@@ -3058,9 +3120,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
-      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.3.tgz",
+      "integrity": "sha512-LLLFZKt4/Nraf9rxDkhiU8QVgLF4WmCkfr0L4fj0fPfIZFBib0DeiFk1hhaYKd03LFAFJcxHslhDFlNJLylf5Q==",
       "cpu": [
         "arm64"
       ],
@@ -3071,9 +3133,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
-      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.3.tgz",
+      "integrity": "sha512-WJkdQCvS9sWNOUBJZfQRKpZGFBztRzcowI+nndmflKgU4XY+3a420FgTOSKTsVqJbnzSxeT4vaJalpOaPo2YCQ==",
       "cpu": [
         "arm64"
       ],
@@ -3084,9 +3146,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
-      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.3.tgz",
+      "integrity": "sha512-PwHXCCS2n64/1Ot6rP1YEYA02MGYBcQlr8CSZZyrUG2O7NH6NklYmvr9v3Jy+5e/eDeNchc/ukmKJi9LuflMIQ==",
       "cpu": [
         "loong64"
       ],
@@ -3097,9 +3159,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
-      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.3.tgz",
+      "integrity": "sha512-vUjxINQu3RC8NZS3ykk1gN65gIz8pAopOq2HXuZhiIxHdx7TFvDG+jgrdSgInu1Eza4/Rfi2VzZgyIgEH4WOaw==",
       "cpu": [
         "loong64"
       ],
@@ -3110,9 +3172,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
-      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.3.tgz",
+      "integrity": "sha512-wzko4aJ13+0G3kGnviCg5gnXFKd40izKsrf2uOw12US4XqprkDrmwOpeW14aSNa37V8bfPcz5Fkob6LZ3BAPmA==",
       "cpu": [
         "ppc64"
       ],
@@ -3123,9 +3185,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
-      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.3.tgz",
+      "integrity": "sha512-8120ue0JUMSwy11stlwnfdX3pPd+WZYGCDBwEHWtIHi6pOpZmsEF5QKB7a/UN+XFdqvobxz98kv8RTqikyCEBw==",
       "cpu": [
         "ppc64"
       ],
@@ -3136,9 +3198,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
-      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.3.tgz",
+      "integrity": "sha512-XLFHnR3tXMjbOCh2vtVJHmxt+995uJsTERQyseFDRA0xxMxyTZPLa3OIUlyFaO4mF/Lu0FjmWHCuPXJT1n/IOg==",
       "cpu": [
         "riscv64"
       ],
@@ -3149,9 +3211,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
-      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.3.tgz",
+      "integrity": "sha512-se6yXvNGMIl0f+RQzyh7XAmia8/9kplQx424wnG2w0C1oi6XgO6Y8otKhdXFHbHs88Ihavzmvh1NWjuovE76BQ==",
       "cpu": [
         "riscv64"
       ],
@@ -3162,9 +3224,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
-      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.3.tgz",
+      "integrity": "sha512-gNoxRefktVIiGflpONuxWWXZAzIQG++z9qHO3xKwk4WdDMuQja3JHGfE1u0i3PfPDyvhypdk+WrgIJqLhGG7sg==",
       "cpu": [
         "s390x"
       ],
@@ -3175,9 +3237,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
-      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.3.tgz",
+      "integrity": "sha512-V4KtWtQfAFMU7+9/A/VDps/VI8CHd3cYz0L8sgJzz8qK7eY7wI4ruFD82UYIYvW9Z4DtlTfhQcsl4XyPHW5uSg==",
       "cpu": [
         "x64"
       ],
@@ -3188,9 +3250,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
-      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.3.tgz",
+      "integrity": "sha512-LBx9LYXvj2CBkMkjLdNAWLwH0MLMin7do2VcVo9kVPibGLkY0BQQut2fv7NVqkXqZ/CrAu9LqDHVV1xHCMpCPw==",
       "cpu": [
         "x64"
       ],
@@ -3201,9 +3263,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
-      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.3.tgz",
+      "integrity": "sha512-ABVf3Q0RCu7NcyCCOZQI0pJ3GuSdfSl8EXcy88QtdceIMIoCUdfhsJChZ64L9zVM2aJHjde1Bhn5uqSRcX9ySA==",
       "cpu": [
         "x64"
       ],
@@ -3214,9 +3276,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
-      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.3.tgz",
+      "integrity": "sha512-+2Cy/ldweGBLlPIKsQLF8U5N44a0KDdbrk1rAjHOM9M2K+kGdIVjHLmmrZIcx+9Ny3ke/1JomCsDI1ocb11+sg==",
       "cpu": [
         "arm64"
       ],
@@ -3227,9 +3289,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
-      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.3.tgz",
+      "integrity": "sha512-dtZvzc8BedpSaFNy75x6uiWwAGTH+aZHDtdrqP6qk+WcLJrfti6sGje1ZJ9UxyzDLF23d/mV+PaMwuC0hL7UVA==",
       "cpu": [
         "arm64"
       ],
@@ -3240,9 +3302,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
-      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.3.tgz",
+      "integrity": "sha512-Rj8Ra4noo+aYy7sKBggCx0407mws34kAb1ySyWuq5DAtFBQdkSwnsjCgPrhPe9cvgBKZIukpE+CVHvORCS93kQ==",
       "cpu": [
         "ia32"
       ],
@@ -3253,9 +3315,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
-      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.3.tgz",
+      "integrity": "sha512-vp7N084ew/odXn2gi/mzm9mUkQu9l6AiN6dt4IeUM2Uvm9o+cVmP+YkqbMOteLbiGgqBBlJZjIMYVCfOOIVbVQ==",
       "cpu": [
         "x64"
       ],
@@ -3266,9 +3328,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
-      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.3.tgz",
+      "integrity": "sha512-MOG/3gTOn4Fwf574RVOaY61I5o6P90legkFADiTyn1hyjNydT+cerU2rLUwPdZkKKyJ+iT+K9p7WXK4LM1Ka6g==",
       "cpu": [
         "x64"
       ],
@@ -3359,9 +3421,9 @@
       "optional": true
     },
     "node_modules/@unhead/bundler": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@unhead/bundler/-/bundler-3.2.2.tgz",
-      "integrity": "sha512-cJN85JdoS5BGzTPfijNvTefnjrwVBmNf3ZTIADFMF54zbh1Zfd9ggC+zql0n+QKDIP/EYYrB73mtvLp/UeMgcQ==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@unhead/bundler/-/bundler-3.2.3.tgz",
+      "integrity": "sha512-fL1LRdTyPYe9dzenElL96yaFW0LcXTUl1RSa5a2ni0n/GxMtvioPwz9y/fD4JnbVG//Kwn3YCv1jfUmlhcoW4g==",
       "license": "MIT",
       "dependencies": {
         "@vitejs/devtools-kit": "^0.4.1",
@@ -3375,11 +3437,11 @@
         "url": "https://github.com/sponsors/harlan-zw"
       },
       "peerDependencies": {
-        "@unhead/cli": "^3.2.2",
+        "@unhead/cli": "^3.2.3",
         "esbuild": ">=0.17.0",
         "lightningcss": ">=1.20.0",
         "rolldown": ">=1.0.0-beta.0",
-        "unhead": "^3.2.2",
+        "unhead": "^3.2.3",
         "vite": ">=6.4.2",
         "webpack": ">=5.0.0"
       },
@@ -3405,14 +3467,14 @@
       }
     },
     "node_modules/@unhead/vue": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@unhead/vue/-/vue-3.2.2.tgz",
-      "integrity": "sha512-5ZGdNA/z8YEH6wBNoX74X6EqzE1oj1pZPIz+3ccWIyllMkAQbMOtja6VGxRLRUc3Fqg6Ik6YmEBBb+OW6RYXTg==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@unhead/vue/-/vue-3.2.3.tgz",
+      "integrity": "sha512-u1qi/0tDyytDSAex8+JMgeDMDlBh3RuzFmTaPOEmbAIx4BG9ej/18ChfM962DC0G7kKhOiuqiSpCfWR5S3XKGg==",
       "license": "MIT",
       "dependencies": {
-        "@unhead/bundler": "3.2.2",
+        "@unhead/bundler": "3.2.3",
         "hookable": "^6.1.1",
-        "unhead": "3.2.2",
+        "unhead": "3.2.3",
         "unplugin": "^3.3.0"
       },
       "funding": {
@@ -3468,145 +3530,22 @@
       }
     },
     "node_modules/@vitejs/devtools-kit": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@vitejs/devtools-kit/-/devtools-kit-0.4.3.tgz",
-      "integrity": "sha512-FjETJwshQQwa9DNeCYtjzfQhvye3e4XMAkDSVmdDicPj8dJM6lJapKTHvNU7SUoxgm8e5tc7OcFyQYaq1xDH3A==",
+      "version": "0.4.10",
+      "resolved": "https://registry.npmjs.org/@vitejs/devtools-kit/-/devtools-kit-0.4.10.tgz",
+      "integrity": "sha512-jaA4FQKlUa5vKrCLSZSJWcZ9DpHSl8j4R7Dq4kPeOmtXngb5eap/ZdumY8f5soCPWarjDKdPi23sAkiLH6VT/g==",
       "license": "MIT",
       "dependencies": {
-        "@devframes/hub": "^0.7.9",
-        "@devframes/json-render": "^0.7.9",
-        "devframe": "^0.7.9",
+        "@devframes/hub": "^0.7.15",
+        "@devframes/json-render": "^0.7.15",
+        "devframe": "^0.7.15",
         "local-pkg": "^1.2.1",
         "mlly": "^1.8.2",
         "nostics": "^1.2.0",
-        "nypm": "^0.6.8"
+        "nypm": "^0.6.9"
       },
       "peerDependencies": {
         "vite": "*"
       }
-    },
-    "node_modules/@vitejs/devtools-kit/node_modules/@devframes/hub": {
-      "version": "0.7.9",
-      "resolved": "https://registry.npmjs.org/@devframes/hub/-/hub-0.7.9.tgz",
-      "integrity": "sha512-+tARSZfwkzez6RKA8ShlntAmfKTn7Z+IM2xwDilNMze5YO+E4n/WmaJBYZL2VvXdDiWB0cJbbwHto+vsrEQB9g==",
-      "license": "MIT",
-      "dependencies": {
-        "birpc": "^4.0.0",
-        "destr": "^2.0.5",
-        "nostics": "^1.2.0",
-        "pathe": "^2.0.3",
-        "perfect-debounce": "^2.1.0",
-        "tinyexec": "^1.2.4",
-        "zigpty": "^0.2.1"
-      },
-      "peerDependencies": {
-        "devframe": "0.7.9"
-      }
-    },
-    "node_modules/@vitejs/devtools-kit/node_modules/@devframes/json-render": {
-      "version": "0.7.9",
-      "resolved": "https://registry.npmjs.org/@devframes/json-render/-/json-render-0.7.9.tgz",
-      "integrity": "sha512-VgUBkxyCG60wTMvihZpGwX9RZwhmhNf+znh/R0Dlwz602E74HtCD2J8jdWqKje4aia4KmmHFLLwWC/itmkfJZg==",
-      "license": "MIT",
-      "dependencies": {
-        "@json-render/core": "^0.19.0",
-        "nostics": "^1.2.0",
-        "zod": "^4.3.6"
-      },
-      "peerDependencies": {
-        "@devframes/hub": "0.7.9",
-        "devframe": "0.7.9"
-      },
-      "peerDependenciesMeta": {
-        "@devframes/hub": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@vitejs/devtools-kit/node_modules/cac": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/cac/-/cac-7.0.0.tgz",
-      "integrity": "sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=20.19.0"
-      }
-    },
-    "node_modules/@vitejs/devtools-kit/node_modules/crossws": {
-      "version": "0.4.10",
-      "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.4.10.tgz",
-      "integrity": "sha512-pz3oubH/dt12KjqsUB0IuXW4nwRDQ583iDsP4555Cpdqx0NoU7pGlWBcayyFI8f/l/idRpgjMEfwuOxSWJYlIA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "srvx": ">=0.11.5"
-      },
-      "peerDependenciesMeta": {
-        "srvx": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@vitejs/devtools-kit/node_modules/devframe": {
-      "version": "0.7.9",
-      "resolved": "https://registry.npmjs.org/devframe/-/devframe-0.7.9.tgz",
-      "integrity": "sha512-ZWSHN5uk6KwCsrCXhu373kdBnk5kxkgxmGpD8tvv5DablgUOfWz+JrP4ufufTrns6PtQFP1Nh5S7sffWoLLp8w==",
-      "license": "MIT",
-      "dependencies": {
-        "@valibot/to-json-schema": "^1.7.1",
-        "birpc": "^4.0.0",
-        "crossws": "^0.4.10",
-        "destr": "^2.0.5",
-        "h3": "2.0.1-rc.22",
-        "mrmime": "^2.0.1",
-        "nostics": "^1.2.0",
-        "pathe": "^2.0.3",
-        "ufo": "^1.6.4",
-        "valibot": "^1.4.2"
-      },
-      "peerDependencies": {
-        "@modelcontextprotocol/sdk": "^1.0.0",
-        "cac": "^7.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@modelcontextprotocol/sdk": {
-          "optional": true
-        },
-        "cac": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@vitejs/devtools-kit/node_modules/h3": {
-      "version": "2.0.1-rc.22",
-      "resolved": "https://registry.npmjs.org/h3/-/h3-2.0.1-rc.22.tgz",
-      "integrity": "sha512-Esv0DMIuPkCTSWCA0vO73vcTqwzH1wjSrAO1TXNu/K3up1sZHa9EKMapbmxCDYBeymC3fVTk4qxp7ogQWQ+KgA==",
-      "license": "MIT",
-      "dependencies": {
-        "rou3": "^0.8.1",
-        "srvx": "^0.11.15"
-      },
-      "bin": {
-        "h3": "bin/h3.mjs"
-      },
-      "engines": {
-        "node": ">=20.11.1"
-      },
-      "peerDependencies": {
-        "crossws": "^0.4.1"
-      },
-      "peerDependenciesMeta": {
-        "crossws": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@vitejs/devtools-kit/node_modules/rou3": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/rou3/-/rou3-0.8.1.tgz",
-      "integrity": "sha512-ePa+XGk00/3HuCqrEnK3LxJW7I0SdNg6EFzKUJG73hMAdDcOUC/i/aSz7LSDwLrGr33kal/rqOGydzwl6U7zBA==",
-      "license": "MIT"
     },
     "node_modules/@vitejs/plugin-vue": {
       "version": "6.0.8",
@@ -3781,34 +3720,34 @@
       }
     },
     "node_modules/@vue/devtools-api": {
-      "version": "8.1.5",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-8.1.5.tgz",
-      "integrity": "sha512-YJipMVAKe5wT5CWf5kTYCaNV7NMNjFVxJkIkJaJ4W/nCxEBzlZzrOsYKeCymdCrFZmBS/+wTWFoUs3Jf/Q6XSQ==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-8.2.1.tgz",
+      "integrity": "sha512-6u4vXBlIBAC1wMplIZgpyPn7uh/s4Bf6F5bMzvLv+EdJ0aHs/+4B7Ygv864EStQSjRbsRzTko/kUG1A1IejQ3A==",
       "license": "MIT",
       "dependencies": {
-        "@vue/devtools-kit": "^8.1.5"
+        "@vue/devtools-kit": "^8.2.1"
       }
     },
     "node_modules/@vue/devtools-core": {
-      "version": "8.1.5",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-core/-/devtools-core-8.1.5.tgz",
-      "integrity": "sha512-5e5jQOEssCdZA1wlFEUkIDtb+cAOWuLNWJ52fm4PBWbF7e3oTnM2fneaL42E5lJoolAaUQ678tv/XEb3h4e86Q==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-core/-/devtools-core-8.2.1.tgz",
+      "integrity": "sha512-s/VfAY9oDTb/kFEWmy461jaFde2MIV1RO/gi1vwM+PAZBZ/Pc2Ndu3BNBdZUze8QDUuyYvElbEEGA83syjJfzA==",
       "license": "MIT",
       "dependencies": {
-        "@vue/devtools-kit": "^8.1.5",
-        "@vue/devtools-shared": "^8.1.5"
+        "@vue/devtools-kit": "^8.2.1",
+        "@vue/devtools-shared": "^8.2.1"
       },
       "peerDependencies": {
         "vue": "^3.0.0"
       }
     },
     "node_modules/@vue/devtools-kit": {
-      "version": "8.1.5",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-8.1.5.tgz",
-      "integrity": "sha512-FcSAxsi4eWuXLCB7Rv9lj0aIVHHPNVQ2BazGf4RJTc2JCqb4BQg0hk87ZFhminCfl+mD5OUI0rX2cgyu4kJOGA==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-8.2.1.tgz",
+      "integrity": "sha512-FIGIuq3AWReEpbAHY/cRGeHDfI0qOb8OCQ3YjbEAX04uaxIDbGc9rhkbVcG7rnfHPXE3RsU5KrWOu9V/okd8AQ==",
       "license": "MIT",
       "dependencies": {
-        "@vue/devtools-shared": "^8.1.5",
+        "@vue/devtools-shared": "^8.2.1",
         "birpc": "^2.6.1",
         "hookable": "^5.5.3",
         "perfect-debounce": "^2.0.0"
@@ -3830,9 +3769,9 @@
       "license": "MIT"
     },
     "node_modules/@vue/devtools-shared": {
-      "version": "8.1.5",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-8.1.5.tgz",
-      "integrity": "sha512-mhT4zcPFhF+Xk1O4BfhhrbXzpmfqY03fS6xGpcllbQG7lDjhQf8pQHcTIhqQIYx1hfwtHmk/6jM96ele0UxPqQ==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-8.2.1.tgz",
+      "integrity": "sha512-Fkac7lUdGReh6pVOi3AYPRGe82LQqRmAfThW7RRligOAP0ZA/Z1z9XLHDM9dv34pV2HRc79DK8uKPeG2fLnA/g==",
       "license": "MIT"
     },
     "node_modules/@vue/reactivity": {
@@ -3918,9 +3857,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
-      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -4060,9 +3999,9 @@
       "license": "MIT"
     },
     "node_modules/archiver-utils/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
+      "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -4241,13 +4180,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
-      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.19.0.tgz",
+      "integrity": "sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
-        "form-data": "^4.0.5",
+        "form-data": "^4.0.6",
         "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
@@ -4389,9 +4328,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.0.tgz",
-      "integrity": "sha512-oCu2wfipvX3AePSgmOuKkIywOu+8n9psz7hXYmk56ghpu3+7KzNIBopaOs4c9BrtdnTtW30unG9GTfHo7EwERQ==",
+      "version": "2.11.7",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.7.tgz",
+      "integrity": "sha512-APw5YuIQAg6L9w4sHDI6j26DGFJI6RpYOhnkMPdC9lWbkKvsyPHzDsve1yd73lk21yz7Y09Kci8B2Pp9FonzWA==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -4437,15 +4376,15 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -4576,14 +4515,12 @@
       }
     },
     "node_modules/cac": {
-      "version": "6.7.14",
-      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
-      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-7.0.0.tgz",
+      "integrity": "sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "engines": {
-        "node": ">=8"
+        "node": ">=20.19.0"
       }
     },
     "node_modules/cache-content-type": {
@@ -4733,6 +4670,29 @@
         "node": ">=20"
       }
     },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/cluster-key-slot": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.1.tgz",
@@ -4783,14 +4743,12 @@
       }
     },
     "node_modules/commander": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
-      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "engines": {
-        "node": ">=22.12.0"
+        "node": ">=16"
       }
     },
     "node_modules/commondir": {
@@ -5363,6 +5321,86 @@
       "integrity": "sha512-DObPPAfdtFbXjxLqK8s2Xk9ZuWz5+ZoFEhC7J76es4GU/rEiXwHTmbImoCdyoCOcBH1UF3+Cz6Z2sYD4hyl5TA==",
       "license": "MIT"
     },
+    "node_modules/devframe": {
+      "version": "0.7.15",
+      "resolved": "https://registry.npmjs.org/devframe/-/devframe-0.7.15.tgz",
+      "integrity": "sha512-pHcCgDILv9BfF0oqEcpPzsPG/2/TLrhcYIUiWTNmP+YiyTmaGkW0osR/48STotnJNi3O2upj5L/6tpLOl/Ravg==",
+      "license": "MIT",
+      "dependencies": {
+        "@valibot/to-json-schema": "^1.7.1",
+        "birpc": "^4.0.0",
+        "crossws": "^0.4.10",
+        "destr": "^2.0.5",
+        "h3": "^2.0.1-rc.26",
+        "mrmime": "^2.0.1",
+        "nostics": "^1.2.0",
+        "pathe": "^2.0.3",
+        "ufo": "^1.6.4",
+        "valibot": "^1.4.2"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.0.0",
+        "cac": "^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        },
+        "cac": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/devframe/node_modules/crossws": {
+      "version": "0.4.10",
+      "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.4.10.tgz",
+      "integrity": "sha512-pz3oubH/dt12KjqsUB0IuXW4nwRDQ583iDsP4555Cpdqx0NoU7pGlWBcayyFI8f/l/idRpgjMEfwuOxSWJYlIA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "srvx": ">=0.11.5"
+      },
+      "peerDependenciesMeta": {
+        "srvx": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/devframe/node_modules/h3": {
+      "version": "2.0.1-rc.26",
+      "resolved": "https://registry.npmjs.org/h3/-/h3-2.0.1-rc.26.tgz",
+      "integrity": "sha512-GDxlvDsKxgjRvG5UBRJYyGJTMWLV30CJ4cV+e7QCTgftDHihrvio1fVPbNembhEr6J4WNm8IWy3fookgyTweLw==",
+      "license": "MIT",
+      "dependencies": {
+        "rou3": "^0.9.1",
+        "srvx": "^0.12.4"
+      },
+      "bin": {
+        "h3": "bin/h3.mjs"
+      },
+      "engines": {
+        "node": ">=20.11.1"
+      },
+      "peerDependencies": {
+        "crossws": "^0.4.9"
+      },
+      "peerDependenciesMeta": {
+        "crossws": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/devframe/node_modules/srvx": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/srvx/-/srvx-0.12.5.tgz",
+      "integrity": "sha512-IuvtDNQg5EIwv3c6dleyau7u8hCyGQ7D6+V/QM799Aud07z0wCUcurKLTRfyG33C8oUY+UWcVBFkfHMcbtmRLA==",
+      "license": "MIT",
+      "bin": {
+        "srvx": "bin/srvx.mjs"
+      },
+      "engines": {
+        "node": ">=20.16.0"
+      }
+    },
     "node_modules/didyoumean": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
@@ -5520,15 +5558,15 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.395",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.395.tgz",
-      "integrity": "sha512-7zt9Aw+SrmxLWLN0zhaTWZQiCdryLVrYTq5R7iZakLvi2UQPYMMsROYV/2qVCzMeCiSXHwKOU+sZ4zOVVlrtKA==",
+      "version": "1.5.398",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.398.tgz",
+      "integrity": "sha512-AsvhAxopJGh6museTDMIjn6JpDYOfgu4RLlygomt87MUwBUqTfd/1EiPtx10/LZE8xpTvkP2E9Gafq7lkLtodQ==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
-      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -5562,9 +5600,9 @@
       }
     },
     "node_modules/errx": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/errx/-/errx-0.1.0.tgz",
-      "integrity": "sha512-fZmsRiDNv07K6s2KkKFTiD2aIvECa7++PKyD5NC32tpRw46qZA3sOz+aM+/V9V0GDHxVTKLziveV4JhzBHDp9Q==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/errx/-/errx-0.1.2.tgz",
+      "integrity": "sha512-chfpPHmCerdo/rXr/nNvPZRkV4WwDRwzwnsJ0Uzz3tVi8Z41tDctRjduYy1138ii77AFlts1qvWtX3g/Acg91Q==",
       "license": "MIT"
     },
     "node_modules/es-define-property": {
@@ -5752,9 +5790,9 @@
       }
     },
     "node_modules/exsolve": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.0.tgz",
-      "integrity": "sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.1.tgz",
+      "integrity": "sha512-9U/jZUgjnSGyntRr6y5Muu1MJcwFl6kPu7k8qLF0IMNfLqvw0NZ4nnVDq0RVoZ0RvCyumib4Ez3KYrVfilrw+g==",
       "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
@@ -5866,9 +5904,9 @@
       }
     },
     "node_modules/fnv1a-64": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/fnv1a-64/-/fnv1a-64-0.1.1.tgz",
-      "integrity": "sha512-qMpkqWyaiNxwYG7Dt40Bxtp2wV6KW/1woXVJOEvR1KA2ffsZf8pyvlNwJgFHha3teh8iC3d4arvrJ0qTcU445A==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/fnv1a-64/-/fnv1a-64-0.1.2.tgz",
+      "integrity": "sha512-mJbcILTPybAR1jdOwt/lVv8N2cffeJFFP+gVbSAwLEx1ujXH27RpPd8Rokec/KX9c76UYIB6Co+H4lQzxPnJfA==",
       "license": "MIT"
     },
     "node_modules/follow-redirects": {
@@ -6011,6 +6049,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/generic-names": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/generic-names/-/generic-names-4.0.0.tgz",
+      "integrity": "sha512-ySFolZQfw9FoDb3ed9d80Cm9f0+r7qj+HJkWjeD9RBfpxEVTlVhol+gvaQB/78WbwYfbnNh8nWHHBSlg072y6A==",
+      "license": "MIT",
+      "dependencies": {
+        "loader-utils": "^3.2.0"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -6103,9 +6150,9 @@
       "license": "MIT"
     },
     "node_modules/giget": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/giget/-/giget-3.3.0.tgz",
-      "integrity": "sha512-gzi2D96p+AMfDcmJHGDj3KJ9NRiwvlFAU5yfa3ROwWZmFUjX4P43x3BcyRaOMMLto1vUo7C+86+MFhYTl6Ryiw==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/giget/-/giget-3.3.1.tgz",
+      "integrity": "sha512-r+mvuDjrjMpsdw46Kmeydb8bdHm7wOKw8wNBtTndkjbPjgAp5oUJUxRE76wZFknxIPokfWvep2qSXK37aXE6zg==",
       "license": "MIT",
       "bin": {
         "giget": "dist/cli.mjs"
@@ -6435,9 +6482,9 @@
       "license": "MIT"
     },
     "node_modules/impound": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/impound/-/impound-1.1.5.tgz",
-      "integrity": "sha512-5AUn+QE0UofqNHu5f2Skf6Svukdg4ehOIq8O0EtqIx4jta0CDZYBPqpIHt0zrlUTiFVYlLpeH39DoikXBjPKpA==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/impound/-/impound-1.1.6.tgz",
+      "integrity": "sha512-ugavDQkE74SGrBjagNIwNVHNBxX14mmfQnTm4jFGzOoWwYsgihqV698BNr5xwRY9quKK4rEg8bc6ECltllMr+w==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.31",
@@ -7395,6 +7442,15 @@
         }
       }
     },
+    "node_modules/loader-utils": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-3.3.1.tgz",
+      "integrity": "sha512-FMJTLMXfCLMLfJxcX9PFqX5qD88Z5MRGaZCVzfuqeZSPsyiBzs+pahDQjbIWz2QIzPZz0NX9Zy4FX3lmK6YHIg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
     "node_modules/local-pkg": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-1.2.1.tgz",
@@ -7455,9 +7511,9 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.0.0.tgz",
-      "integrity": "sha512-CGvjzMN08iv6w1mm4/x3Gh1hLb4VnyRUA15FFpl6CsCIGGoe36k7kY5KNz9QDbSBN5I/fWHM6ZlIkUTa5xdUEA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.1.0.tgz",
+      "integrity": "sha512-kS3VHe0nEPST2saQV4Rbkchcd3UBRkVTQHo1D3h/ZTwFDhai/mfKkmtPAtD129EOI7K3HlHIsFOt0WrI2/oU9g==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -7620,12 +7676,12 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.5"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -7925,9 +7981,9 @@
       }
     },
     "node_modules/node-mock-http": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/node-mock-http/-/node-mock-http-1.0.4.tgz",
-      "integrity": "sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/node-mock-http/-/node-mock-http-1.0.5.tgz",
+      "integrity": "sha512-KQyt/wLjG3TAc7DOUhpqWzgd4ERxR80JOlTK5VE5R1S12IaPVN5qkj4klBce9HPG1Njuup4Sb5bljaT34lIyjw==",
       "license": "MIT"
     },
     "node_modules/node-releases": {
@@ -8009,41 +8065,41 @@
       }
     },
     "node_modules/nuxt": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/nuxt/-/nuxt-4.5.0.tgz",
-      "integrity": "sha512-MbMAQFR9q8sDf80mp0v1sLtPuFDviSw7ntcBHPP0ok9phpirRy19NM9aDNRI6/12hU646BurrE0zCFJK0pq7NA==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/nuxt/-/nuxt-4.5.1.tgz",
+      "integrity": "sha512-bDfkB3VKenF7diLS+r6hBGjW/5hyH35q2xHZ355jEYuD1/dVC/3DW8yW8P+8p+Qk8MX+J0TmD66+jxnCandEpA==",
       "license": "MIT",
       "dependencies": {
         "@dxup/nuxt": "^0.5.3",
         "@nuxt/cli": "^3.37.0",
-        "@nuxt/devtools": "^3.2.4",
-        "@nuxt/kit": "4.5.0",
-        "@nuxt/nitro-server": "4.5.0",
-        "@nuxt/schema": "4.5.0",
+        "@nuxt/devtools": "^3.3.1",
+        "@nuxt/kit": "4.5.1",
+        "@nuxt/nitro-server": "4.5.1",
+        "@nuxt/schema": "4.5.1",
         "@nuxt/telemetry": "^2.8.0",
-        "@nuxt/vite-builder": "4.5.0",
-        "@unhead/vue": "^3.1.8",
-        "@vue/shared": "^3.5.39",
+        "@nuxt/vite-builder": "4.5.1",
+        "@unhead/vue": "^3.2.3",
+        "@vue/shared": "^3.5.40",
         "chokidar": "^5.0.0",
         "compatx": "^0.2.0",
         "consola": "^3.4.2",
         "cookie-es": "^3.1.1",
         "defu": "^6.1.7",
-        "devalue": "^5.8.1",
+        "devalue": "^5.8.2",
         "errx": "^0.1.0",
         "escape-string-regexp": "^5.0.0",
         "exsolve": "^1.1.0",
         "fnv1a-64": "^0.1.1",
         "hookable": "^6.1.1",
         "ignore": "^7.0.6",
-        "impound": "^1.1.5",
+        "impound": "^1.1.6",
         "jiti": "^2.7.0",
         "klona": "^2.0.6",
         "knitwork": "^1.3.0",
         "magic-string": "^1.0.0",
         "mlly": "^1.8.2",
         "nanotar": "^0.3.0",
-        "nostics": "^1.1.4",
+        "nostics": "^1.2.0",
         "nypm": "^0.6.8",
         "object-identity": "^0.2.3",
         "ofetch": "^1.5.1",
@@ -8055,23 +8111,23 @@
         "picomatch": "^4.0.5",
         "pkg-types": "^2.3.1",
         "rolldown": "^1.2.0",
-        "rolldown-string": "^0.3.0",
+        "rolldown-string": "^0.3.1",
         "rou3": "^0.9.1",
         "scule": "^1.3.0",
-        "semver": "^7.8.5",
         "std-env": "^4.2.0",
         "tinyglobby": "^0.2.17",
         "ufo": "^1.6.4",
         "ultrahtml": "^1.7.0",
         "uncrypto": "^0.1.3",
         "unctx": "^3.0.0",
-        "undici": "^8.7.0",
-        "unhead": "^3.1.8",
-        "unimport": "^6.3.0",
+        "undici": "^8.8.0",
+        "unhead": "^3.2.3",
+        "unimport": "^6.3.1",
         "unplugin": "^3.3.0",
-        "unrouting": "^0.1.7",
+        "unrouting": "^0.2.2",
         "untyped": "^2.0.0",
-        "vue": "^3.5.39",
+        "verkit": "^0.2.0",
+        "vue": "^3.5.40",
         "vue-router": "^5.2.0"
       },
       "bin": {
@@ -8095,9 +8151,9 @@
       }
     },
     "node_modules/nuxt/node_modules/@nuxt/kit": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-4.5.0.tgz",
-      "integrity": "sha512-VD4GjRjbh7r7ILoXYbiKeQgZuYP/vJ7iMk6fSRak1+xEyXHpQ+OIq/EfIjfsHv7DVimddOB+I6W/wGXjRVZ+Ng==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-4.5.1.tgz",
+      "integrity": "sha512-xDXQspE2blxaZwxwGknL/BqaIbkLizl85Ov+pbSlPPd/rw2KjJGx88RHU5SwoQNwCiSC5hWZBnVAznIsq1xNHQ==",
       "license": "MIT",
       "dependencies": {
         "c12": "^3.3.4",
@@ -8110,17 +8166,17 @@
         "jiti": "^2.7.0",
         "klona": "^2.0.6",
         "mlly": "^1.8.2",
-        "nostics": "^1.1.4",
+        "nostics": "^1.2.0",
         "ohash": "^2.0.11",
         "pathe": "^2.0.3",
         "pkg-types": "^2.3.1",
         "rc9": "^3.0.1",
         "scule": "^1.3.0",
-        "semver": "^7.8.5",
         "tinyglobby": "^0.2.17",
         "ufo": "^1.6.4",
         "unctx": "^3.0.0",
-        "untyped": "^2.0.0"
+        "untyped": "^2.0.0",
+        "verkit": "^0.2.0"
       },
       "engines": {
         "node": ">=18.12.0"
@@ -8159,9 +8215,9 @@
       }
     },
     "node_modules/nypm": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.8.tgz",
-      "integrity": "sha512-Q9K4Diu6l5u6xJQogeFSs/zKtyMSgFKFtRQV+tHP4kL7KPm2grpBU0dFIwFaXwNxN0MtfKWc43VpCugAa+LPsw==",
+      "version": "0.6.9",
+      "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.9.tgz",
+      "integrity": "sha512-zxlE2yvSWZWmHcNdT3+5zV2lrCogeE9YOklHrR3dFjqutq5wO7GFDYLFDRXLsYnJzwvy/im9fYoxePvS0VTW0w==",
       "license": "MIT",
       "dependencies": {
         "citty": "^0.2.2",
@@ -8506,9 +8562,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.22",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
-      "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "funding": [
         {
           "type": "opencollective",
@@ -9318,9 +9374,9 @@
       "license": "MIT"
     },
     "node_modules/readdir-glob/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
+      "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -9429,12 +9485,6 @@
       "engines": {
         "node": ">=12"
       }
-    },
-    "node_modules/replace-in-file/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "license": "MIT"
     },
     "node_modules/replace-in-file/node_modules/glob": {
       "version": "11.1.0",
@@ -9662,12 +9712,12 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.0.tgz",
-      "integrity": "sha512-u7tgm5l4Yw1iTqUL4EcYOAt7fFvCgQMLeidrnD4GALlC6aOznCjezYajgxeyKw27u0Q5N7fwgCzjVyPIWzwuBA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.1.tgz",
+      "integrity": "sha512-4FKJhg8d3OiyQOA6Q1Q0hoFFpW9/OoX+VsHzpECsdsIZoOArrAK90gl59YK/Z+gnDel45bgJZK03ozH/9bCqEw==",
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.140.0",
+        "@oxc-project/types": "=0.142.0",
         "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
@@ -9677,21 +9727,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.2.0",
-        "@rolldown/binding-darwin-arm64": "1.2.0",
-        "@rolldown/binding-darwin-x64": "1.2.0",
-        "@rolldown/binding-freebsd-x64": "1.2.0",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.2.0",
-        "@rolldown/binding-linux-arm64-gnu": "1.2.0",
-        "@rolldown/binding-linux-arm64-musl": "1.2.0",
-        "@rolldown/binding-linux-ppc64-gnu": "1.2.0",
-        "@rolldown/binding-linux-s390x-gnu": "1.2.0",
-        "@rolldown/binding-linux-x64-gnu": "1.2.0",
-        "@rolldown/binding-linux-x64-musl": "1.2.0",
-        "@rolldown/binding-openharmony-arm64": "1.2.0",
-        "@rolldown/binding-wasm32-wasi": "1.2.0",
-        "@rolldown/binding-win32-arm64-msvc": "1.2.0",
-        "@rolldown/binding-win32-x64-msvc": "1.2.0"
+        "@rolldown/binding-android-arm64": "1.2.1",
+        "@rolldown/binding-darwin-arm64": "1.2.1",
+        "@rolldown/binding-darwin-x64": "1.2.1",
+        "@rolldown/binding-freebsd-x64": "1.2.1",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.1",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.1",
+        "@rolldown/binding-linux-arm64-musl": "1.2.1",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.1",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.1",
+        "@rolldown/binding-linux-x64-gnu": "1.2.1",
+        "@rolldown/binding-linux-x64-musl": "1.2.1",
+        "@rolldown/binding-openharmony-arm64": "1.2.1",
+        "@rolldown/binding-wasm32-wasi": "1.2.1",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.1",
+        "@rolldown/binding-win32-x64-msvc": "1.2.1"
       }
     },
     "node_modules/rolldown-string": {
@@ -9717,10 +9767,19 @@
         }
       }
     },
+    "node_modules/rolldown/node_modules/@oxc-project/types": {
+      "version": "0.142.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.142.0.tgz",
+      "integrity": "sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
     "node_modules/rollup": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
-      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.3.tgz",
+      "integrity": "sha512-Gu0c0iH9FzgX1L1t7ByIbbS3Vmdz+6KHm/EsqmmC71gUQ82yvZRkTK6XzrFObSka91WUVdynqp6nsfilzr5k6Q==",
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.9"
@@ -9733,31 +9792,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.62.2",
-        "@rollup/rollup-android-arm64": "4.62.2",
-        "@rollup/rollup-darwin-arm64": "4.62.2",
-        "@rollup/rollup-darwin-x64": "4.62.2",
-        "@rollup/rollup-freebsd-arm64": "4.62.2",
-        "@rollup/rollup-freebsd-x64": "4.62.2",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
-        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
-        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
-        "@rollup/rollup-linux-arm64-musl": "4.62.2",
-        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
-        "@rollup/rollup-linux-loong64-musl": "4.62.2",
-        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
-        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
-        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
-        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
-        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
-        "@rollup/rollup-linux-x64-gnu": "4.62.2",
-        "@rollup/rollup-linux-x64-musl": "4.62.2",
-        "@rollup/rollup-openbsd-x64": "4.62.2",
-        "@rollup/rollup-openharmony-arm64": "4.62.2",
-        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
-        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
-        "@rollup/rollup-win32-x64-gnu": "4.62.2",
-        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "@rollup/rollup-android-arm-eabi": "4.62.3",
+        "@rollup/rollup-android-arm64": "4.62.3",
+        "@rollup/rollup-darwin-arm64": "4.62.3",
+        "@rollup/rollup-darwin-x64": "4.62.3",
+        "@rollup/rollup-freebsd-arm64": "4.62.3",
+        "@rollup/rollup-freebsd-x64": "4.62.3",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.3",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.3",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.3",
+        "@rollup/rollup-linux-arm64-musl": "4.62.3",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.3",
+        "@rollup/rollup-linux-loong64-musl": "4.62.3",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.3",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.3",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.3",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.3",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.3",
+        "@rollup/rollup-linux-x64-gnu": "4.62.3",
+        "@rollup/rollup-linux-x64-musl": "4.62.3",
+        "@rollup/rollup-openbsd-x64": "4.62.3",
+        "@rollup/rollup-openharmony-arm64": "4.62.3",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.3",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.3",
+        "@rollup/rollup-win32-x64-gnu": "4.62.3",
+        "@rollup/rollup-win32-x64-msvc": "4.62.3",
         "fsevents": "~2.3.2"
       }
     },
@@ -9870,9 +9929,9 @@
       }
     },
     "node_modules/sax": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
-      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+      "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
@@ -9957,9 +10016,9 @@
       }
     },
     "node_modules/seroval": {
-      "version": "1.5.6",
-      "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.6.tgz",
-      "integrity": "sha512-rVQVWjjSvlINzaQPZH5JFqsqEsIWdTxY3iJZCnTL/5gQbXIRooVZKI60tVCkOVfzcRPejboxO2t0P89dg5mQaA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.6.0.tgz",
+      "integrity": "sha512-TBwwKfscTEgnBEWmYKKeCcmCGmrJi0LV6qNUY//WBA3MDesh/zfn+KOMq/ckpxM4gZ0ouAE706A1eenekM2sug==",
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -10265,17 +10324,16 @@
       }
     },
     "node_modules/string-width": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+      "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
       "license": "MIT",
       "dependencies": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
-        "strip-ansi": "^7.1.0"
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -10304,12 +10362,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/string-width-cjs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "license": "MIT"
     },
     "node_modules/string-width-cjs/node_modules/strip-ansi": {
       "version": "6.0.1",
@@ -10373,27 +10425,21 @@
       }
     },
     "node_modules/strip-literal": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
-      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-4.0.0.tgz",
+      "integrity": "sha512-PaqAvfUZKBwc/SLmNZtHmzK+v19Z4O4eS3cKPeGvbIv/U3pnyEq4Tuw3/4v/FwfM8VQaEawsyCcOQ0P+kpwWWw==",
       "license": "MIT",
       "dependencies": {
-        "js-tokens": "^9.0.1"
+        "js-tokens": "^10.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
     },
-    "node_modules/strip-literal/node_modules/js-tokens": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
-      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
-      "license": "MIT"
-    },
     "node_modules/structured-clone-es": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/structured-clone-es/-/structured-clone-es-2.0.0.tgz",
-      "integrity": "sha512-5UuAHmBLXYPCl22xWJrFuGmIhBKQzxISPVz6E7nmTmTcAOpUzlbjKJsRrCE4vADmMQ0dzeCnlWn9XufnAGf76Q==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/structured-clone-es/-/structured-clone-es-2.0.1.tgz",
+      "integrity": "sha512-10ZL5r77LhknxlP1FBiCW+VdnuWOEFLdSS2SKtjyEV+L4qP1hUEIMIZW94LC3jKxRmT/Dj7KkD1mqh/IY6lhKQ==",
       "license": "ISC"
     },
     "node_modules/stylehacks": {
@@ -10490,15 +10536,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/svgo"
-      }
-    },
-    "node_modules/svgo/node_modules/commander": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
-      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
       }
     },
     "node_modules/tagged-tag": {
@@ -10723,9 +10760,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.21",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.21.tgz",
-      "integrity": "sha512-XdhtCvlMywwxpCW8YEq3lOXBJpUPTR2OHHcwLPO3HwsJqOHa2Ok/oJ7ruGzp+JrKoRPVCzJwAdEjqLW/vNRPHA==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -11017,9 +11054,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.8.0.tgz",
-      "integrity": "sha512-ubshXMXwF3MQIMF1y/WxZdNBnjEKeSg2wF5mcGUtU55YTw34tnVVpKRlLf7ruDXZ5344KokPVX4RBx1wJm64Bw==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.9.0.tgz",
+      "integrity": "sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==",
       "license": "MIT",
       "engines": {
         "node": ">=22.19.0"
@@ -11035,9 +11072,9 @@
       }
     },
     "node_modules/unhead": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/unhead/-/unhead-3.2.2.tgz",
-      "integrity": "sha512-1sp6E2pzYneEdLlhzboRSZJlJgqugvzfNP5hNYntx9YZmSRNT6KewddzMWUPfmo3qUgWlKxuKvI2mrjcnQ9SjA==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/unhead/-/unhead-3.2.3.tgz",
+      "integrity": "sha512-BBkKvthUOufEJzG4C4u5NCdxnGMNaQdb//oPDI8lkv/6qj0faEqnPIvIPejt3FnSE501LX25Gbe2MVgKDuFnyQ==",
       "license": "MIT",
       "dependencies": {
         "hookable": "^6.1.1",
@@ -11068,25 +11105,25 @@
       }
     },
     "node_modules/unimport": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/unimport/-/unimport-6.3.1.tgz",
-      "integrity": "sha512-43BV4iELfhpZ0JNSedMNdBqomAIaJwBrmTqIUYRb8ly3XVQihcRPAVIOSwb23XVCJgtjSf+f82d5Qpdsxqh8iQ==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/unimport/-/unimport-6.4.0.tgz",
+      "integrity": "sha512-JJOOuNMFq8b4ZPBKwQUxEcba4MplskDzYI1Lvrf8rJfWphZTWvPNXWa493qsPngHUmub89w6C7j+SeLWTE/UIQ==",
       "license": "MIT",
       "dependencies": {
-        "acorn": "^8.16.0",
+        "acorn": "^8.18.0",
         "escape-string-regexp": "^5.0.0",
         "estree-walker": "^3.0.3",
-        "local-pkg": "^1.1.2",
-        "magic-string": "^0.30.21",
+        "local-pkg": "^1.2.1",
+        "magic-string": "^1.1.0",
         "mlly": "^1.8.2",
         "pathe": "^2.0.3",
-        "picomatch": "^4.0.4",
+        "picomatch": "^4.0.5",
         "pkg-types": "^2.3.1",
         "scule": "^1.3.0",
-        "strip-literal": "^3.1.0",
-        "tinyglobby": "^0.2.16",
-        "unplugin": "^3.0.0",
-        "unplugin-utils": "^0.3.1"
+        "strip-literal": "^4.0.0",
+        "tinyglobby": "^0.2.17",
+        "unplugin": "^3.3.0",
+        "unplugin-utils": "^0.3.2"
       },
       "engines": {
         "node": ">=18.12.0"
@@ -11111,15 +11148,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
-      }
-    },
-    "node_modules/unimport/node_modules/magic-string": {
-      "version": "0.30.21",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
-      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/universalify": {
@@ -11202,9 +11230,9 @@
       }
     },
     "node_modules/unrouting": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/unrouting/-/unrouting-0.1.7.tgz",
-      "integrity": "sha512-+0hfD+CVWtD636rc5Fn9VEjjTEDhdqgMpbwAuVoUmydSHDaMNiFW93SJG4LV++RoGSEAyvQN5uABAscYpDphpQ==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/unrouting/-/unrouting-0.2.2.tgz",
+      "integrity": "sha512-EoCab68s1o9AWFq9fjKsMEsmjKrPO11SAsvopikks2eEm/KLXgZMCof4cgpVgdy0Vz71OFBJw6DoDqu1oOSFGw==",
       "license": "MIT",
       "dependencies": {
         "escape-string-regexp": "^5.0.0",
@@ -11451,6 +11479,18 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/verkit": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/verkit/-/verkit-0.2.0.tgz",
+      "integrity": "sha512-6M8R2xSKplkQ+0mAm07IMh548GLLPUnRQZJCCe/W4rfk/SXW2bs8ZJSWa5kjdIdsx3hLG5oLWROJ4+N5hpX08g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sxzz"
+      }
+    },
     "node_modules/vite": {
       "version": "8.1.5",
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
@@ -11578,19 +11618,10 @@
         "url": "https://opencollective.com/antfu"
       }
     },
-    "node_modules/vite-node/node_modules/cac": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/cac/-/cac-7.0.0.tgz",
-      "integrity": "sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.19.0"
-      }
-    },
     "node_modules/vite-plugin-checker": {
-      "version": "0.14.4",
-      "resolved": "https://registry.npmjs.org/vite-plugin-checker/-/vite-plugin-checker-0.14.4.tgz",
-      "integrity": "sha512-Tw0U9UgHIRiZ+Yoe4Gh0RrYoBiCVmO9j4tomVdYr0KUjUsqXMPhqW8ouoSWmOzGp5Iimipbl3bNXZcK7OeP7Qg==",
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/vite-plugin-checker/-/vite-plugin-checker-0.14.5.tgz",
+      "integrity": "sha512-c9lQ92eisUO+F7Fd93aelojmiOS+NQpPgQ1XR2LTQHox1/laZf4yAoQj+L3RA9Vgh10e2nFd9b8r2LLyYZsbpA==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
@@ -12295,12 +12326,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "license": "MIT"
-    },
     "node_modules/wrap-ansi-cjs/node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -12337,6 +12362,29 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ws": {
@@ -12407,15 +12455,15 @@
       }
     },
     "node_modules/yargs": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
-      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.1.0.tgz",
+      "integrity": "sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==",
       "license": "MIT",
       "dependencies": {
         "cliui": "^9.0.1",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
-        "string-width": "^7.2.0",
+        "string-width": "^8.2.1",
         "y18n": "^5.0.5",
         "yargs-parser": "^22.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kickstart-nuxt-ssr",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "private": false,
   "repository": {
     "type": "git",
@@ -18,17 +18,17 @@
     "postinstall": "nuxt prepare"
   },
   "dependencies": {
-    "@contentstack/delivery-sdk": "^5.4.0",
+    "@contentstack/delivery-sdk": "^5.5.0",
     "@contentstack/live-preview-utils": "^4.4.5",
     "@contentstack/utils": "^1.9.1",
     "@nuxtjs/tailwindcss": "^6.14.0",
-    "nuxt": "^4.5.0",
+    "nuxt": "^4.5.1",
     "vue": "^3.5.40",
     "vue-router": "^5.2.0"
   },
   "optionalDependencies": {
-    "@rollup/rollup-linux-x64-gnu": "^4.62.2",
-    "@rollup/rollup-linux-x64-musl": "^4.62.2"
+    "@rollup/rollup-linux-x64-gnu": "^4.62.3",
+    "@rollup/rollup-linux-x64-musl": "^4.62.3"
   },
   "overrides": {
     "replace-in-file": {


### PR DESCRIPTION
## Summary

- Bump package version from `1.1.2` to `1.1.3`
- Update Contentstack and third-party dependencies to their latest compatible versions
- Add `.npmrc` to fix `npm install` crash on fresh clones

## Dependency Changes

| Package | From | To |
|---|---|---|
| `@contentstack/delivery-sdk` | `^5.4.0` | `^5.5.0` |
| `nuxt` | `^4.5.0` | `^4.5.1` |
| `@rollup/rollup-linux-x64-gnu` | `^4.62.2` | `^4.62.3` |
| `@rollup/rollup-linux-x64-musl` | `^4.62.2` | `^4.62.3` |

## Fix: `.npmrc` — `legacy-peer-deps=true`

`npm install` was crashing with `Cannot read properties of null (reading 'edgesOut')` due to a known npm arborist bug triggered by `nuxt@^4.5.1`'s peer dependency graph. Adding `legacy-peer-deps=true` to `.npmrc` resolves this for anyone cloning the repo without needing to pass the flag manually.

## Test plan

- [ ] `npm install` completes without errors on a fresh clone
- [ ] `npm run build` succeeds
- [ ] SSR rendering verified end-to-end
- [ ] Live preview functionality verified with updated `@contentstack/live-preview-utils`
- [ ] No regressions in content delivery with updated `@contentstack/delivery-sdk`